### PR TITLE
Add the MovFlags setting support.

### DIFF
--- a/Hudl.Ffmpeg.Tests/Setting/SettingCollectionTests.cs
+++ b/Hudl.Ffmpeg.Tests/Setting/SettingCollectionTests.cs
@@ -210,5 +210,18 @@ namespace Hudl.Ffmpeg.Tests.Setting
             Assert.DoesNotThrow(() => { var s = setting.ToString(); });
             Assert.Equal(setting.ToString(), "-crf 18");
         }
+
+        [Fact]
+        public void Settings_MovFlags()
+        {
+            var settingWrong1 = new MovFlags(string.Empty);
+            var settingWrong2 = new MovFlags("  ");
+            var setting = new MovFlags(MovFlags.EnableFastStart);
+
+            Assert.Throws<InvalidOperationException>(() => { var s = settingWrong1.ToString(); });
+            Assert.Throws<InvalidOperationException>(() => { var s = settingWrong2.ToString(); });
+            Assert.DoesNotThrow(() => { var s = setting.ToString(); });
+            Assert.Equal(setting.ToString(), "-movflags +faststart");
+        }
     }
 }

--- a/Hudl.Ffmpeg/Hudl.Ffmpeg.csproj
+++ b/Hudl.Ffmpeg/Hudl.Ffmpeg.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Logging\LogUtility.cs" />
     <Compile Include="Resources\VideoTxt.cs" />
     <Compile Include="Settings\BaseTypes\BaseFormat.cs" />
+    <Compile Include="Settings\MovFlags.cs" />
     <Compile Include="Settings\FormatInput.cs" />
     <Compile Include="Settings\FormatOutput.cs" />
     <Compile Include="Settings\ConstantRateFactor.cs" />

--- a/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
@@ -35,6 +35,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyInformationalVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/Hudl.Ffmpeg/Settings/MovFlags.cs
+++ b/Hudl.Ffmpeg/Settings/MovFlags.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Hudl.Ffmpeg.BaseTypes;
+using Hudl.Ffmpeg.Common;
+using Hudl.Ffmpeg.Resources.BaseTypes;
+using Hudl.Ffmpeg.Settings.BaseTypes;
+
+namespace Hudl.Ffmpeg.Settings
+{
+    /// <summary>
+    /// MovFlags sets the LibAV Encoder options to enable features and options in the video
+    /// </summary>
+    [AppliesToResource(Type = typeof(IAudio))]
+    [AppliesToResource(Type = typeof(IVideo))]
+    [SettingsApplication(PreDeclaration = true, ResourceType = SettingsCollectionResourceType.Output)]
+    public class MovFlags : BaseSetting
+    {
+        private const string SettingType = "-movflags";
+        public const string EnableFastStart = "+faststart"; 
+
+        public MovFlags(string flags)
+            : base(SettingType)
+        {
+            Flags = flags;
+        }
+    
+        public string Flags { get; set; }
+
+        public override string ToString()
+        {
+            if (string.IsNullOrWhiteSpace(Flags))
+            {
+                throw new InvalidOperationException("MovFlags cannot be null or empty.");
+            }
+
+            return string.Concat(Type, " ", Flags);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Since we use h.264 (AVC) in our Mp4s we need support for the best possible streaming available. So we need the `-movflags +faststart` option to be added during the final concatenation of our end videos. What this does is move the `moov atom` to the beginning of the file so that browsers have enough information to start the streaming. 
## Testing Considerations
- [ ] Test a video that runs over 5 minutes long to ensure playback happens before full buffer is achieved. 
