### PR TITLE
Adding Millisecond accuracy to timestamps in Ffmpeg.

### DIFF
--- a/Hudl.Ffmpeg/Common/Formats.cs
+++ b/Hudl.Ffmpeg/Common/Formats.cs
@@ -15,10 +15,11 @@ namespace Hudl.Ffmpeg.Common
         }
         public static string Duration(TimeSpan timespan)
         {
-            return string.Format("{0}:{1}:{2}",
+            return string.Format("{0}:{1}:{2}.{3}",
                                  timespan.Hours.ToString(CultureInfo.InvariantCulture).PadLeft(2, '0'),
                                  timespan.Minutes.ToString(CultureInfo.InvariantCulture).PadLeft(2, '0'),
-                                 timespan.Seconds.ToString(CultureInfo.InvariantCulture).PadLeft(2, '0'));
+                                 timespan.Seconds.ToString(CultureInfo.InvariantCulture).PadLeft(2, '0'), 
+                                 timespan.Milliseconds.ToString(CultureInfo.InvariantCulture));
         }
         public static string Map(IResource input, int index)
         {

--- a/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
@@ -35,6 +35,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("1.7.0.0")]
-[assembly: AssemblyFileVersion("1.7.0.0")]
+[assembly: AssemblyInformationalVersion("1.8.0.0")]
+[assembly: AssemblyFileVersion("1.8.0.0")]
 [assembly: AssemblyVersion("1.0.0.0")]


### PR DESCRIPTION
For quite some time this has gone unnoticed, but we need millisecond accuracy in Hudl.Ffmpeg on duration timestamps
