### PR TITLE
Allow attributes for extensions

### DIFF
--- a/Hudl.Ffmpeg/BaseTypes/ContainsStreamAttribute.cs
+++ b/Hudl.Ffmpeg/BaseTypes/ContainsStreamAttribute.cs
@@ -6,7 +6,7 @@ namespace Hudl.FFmpeg.BaseTypes
     /// class level attribute that sets up a connection between a type with a resource
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple=true, Inherited=true)]
-    class ContainsStreamAttribute : Attribute
+    public class ContainsStreamAttribute : Attribute
     {
         public Type Type { get; set; }
     }

--- a/Hudl.Ffmpeg/BaseTypes/ForStreamAttribute.cs
+++ b/Hudl.Ffmpeg/BaseTypes/ForStreamAttribute.cs
@@ -6,7 +6,7 @@ namespace Hudl.FFmpeg.BaseTypes
     /// class level attribute that sets up a connection between a type with a resource
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple=true, Inherited=true)]
-    class ForStreamAttribute : Attribute
+    public class ForStreamAttribute : Attribute
     {
         public Type Type { get; set; }
     }

--- a/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
@@ -35,6 +35,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyInformationalVersion("2.1.0.0")]
+[assembly: AssemblyFileVersion("2.1.0.0")]
 [assembly: AssemblyVersion("1.0.0.0")]


### PR DESCRIPTION
## Description

In order for extensions objects to work with Hudl.FFmpeg nicely we needed to make a few attributes accessible. For starters the `HasStreamAttribute` allows the user to define the streams that belong in a specified `IContainer`. Secondly the `ForStreamAttribute` allows the user to define stream type contraints for specific `ISetting` and `IFilter`. 
