### PR TITLE
Issue with nuget targets pointing to an internal server

### DIFF
--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -16,7 +16,6 @@
         <DownloadNuGetExe Condition=" '$(DownloadNuGetExe)' == '' ">false</DownloadNuGetExe>
 
         <!-- Set a default local package repo if it hasn't been set by the environment -->
-        <NuGetRepo Condition=" '$(NuGetRepo)' == '' ">http://nuget.thorhudl.com/nuget/</NuGetRepo>
         <NuGetRepo Condition=" '$(NuGetRepo)' == '' ">https://www.nuget.org/api/v2/</NuGetRepo>
     </PropertyGroup>
     

--- a/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
@@ -35,6 +35,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+[assembly: AssemblyInformationalVersion("2.1.1.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
 [assembly: AssemblyVersion("1.0.0.0")]


### PR DESCRIPTION
To prevent people from breaking when pulling locally we need to strip off the internal server path from our nuget.targets.