### PR TITLE
Add BoxBlur video filter to library of default filters

### DIFF
--- a/Hudl.Ffmpeg.Tests/Filter/FilterTests.cs
+++ b/Hudl.Ffmpeg.Tests/Filter/FilterTests.cs
@@ -167,6 +167,18 @@ namespace Hudl.FFmpeg.Tests.Filter
         }
 
         [Fact]
+        public void BoxBlur_Verify()
+        {
+            var filter = FilterFactory.CreateEmpty<BoxBlur>();
+            var filterValue = new StringBuilder(100);
+            Assert.DoesNotThrow(() => { var s = filter.ToString(); });
+
+            filter.Expression = "15:1"; 
+            filterValue.Append("boxblur=15:1");
+            Assert.Equal(filter.ToString(), filterValue.ToString());
+        }
+
+        [Fact]
         public void AMix_Verify()
         {
             var filter = FilterFactory.CreateEmpty<AMix>();

--- a/Hudl.Ffmpeg/Filters/BoxBlur.cs
+++ b/Hudl.Ffmpeg/Filters/BoxBlur.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Text;
+using Hudl.FFmpeg.BaseTypes;
+using Hudl.FFmpeg.Common;
+using Hudl.FFmpeg.Filters.BaseTypes;
+using Hudl.FFmpeg.Resources.BaseTypes;
+
+namespace Hudl.FFmpeg.Filters
+{
+    /// <summary>
+    /// Video filter that applies a boxblur algorithm to the input video.
+    /// </summary>
+    [ForStream(Type=typeof(VideoStream))]
+    public class BoxBlur : BaseFilter
+    {
+        private const int FilterMaxInputs = 1;
+        private const string FilterType = "boxblur";
+
+         public BoxBlur()
+            : base(FilterType, FilterMaxInputs)
+        {
+        }
+
+        public BoxBlur(string expression)
+            : this()
+        {
+            Expression = expression; 
+        }
+
+        public string Expression { get; set; }
+
+        public override void Validate()
+        {
+            if (string.IsNullOrWhiteSpace(Expression))
+            {
+                throw new InvalidOperationException("Expression of the BoxBlur cannot be null or whitespace.");
+            }
+        }
+
+        public override string ToString()
+        {
+            var filterParameters = new StringBuilder(100);
+
+            if (!string.IsNullOrWhiteSpace(Expression))
+            {
+                FilterUtility.ConcatenateParameter(filterParameters, Expression); 
+            }
+
+            return FilterUtility.JoinTypeAndParameters(this, filterParameters);
+        }
+    }
+}

--- a/Hudl.Ffmpeg/Hudl.Ffmpeg.csproj
+++ b/Hudl.Ffmpeg/Hudl.Ffmpeg.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Command\FFprobeCommand.cs" />
     <Compile Include="Common\FFmpegFraction.cs" />
     <Compile Include="Common\FFmpegStreamTypes.cs" />
+    <Compile Include="Filters\BoxBlur.cs" />
     <Compile Include="Metadata\Ffprobe\BaseTypes\FFprobeCodecTypes.cs" />
     <Compile Include="Metadata\Ffprobe\BaseTypes\FFprobeObject.cs" />
     <Compile Include="Metadata\Ffprobe\FFprobeVideoStream.cs" />

--- a/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
@@ -35,6 +35,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+[assembly: AssemblyInformationalVersion("2.1.1.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
 [assembly: AssemblyVersion("1.0.0.0")]


### PR DESCRIPTION
## Description 
Added the ```boxblur``` video filter to the library. This new filter accepts a string expression. New tests were added to ensure proper ffmpeg syntax was maintained.  The filter takes in a singular input video stream and outputs a single input video stream.

```
boxblur={expression}
```