### PR TITLE
Renamed SCThreshold to SceneChangeThreshold

### DIFF
--- a/Hudl.Ffmpeg.Tests/Setting/SettingCollectionTests.cs
+++ b/Hudl.Ffmpeg.Tests/Setting/SettingCollectionTests.cs
@@ -279,10 +279,10 @@ namespace Hudl.Ffmpeg.Tests.Setting
             Assert.Equal(setting.ToString(), "-keyint_min 20");
         }
         [Fact]
-        public void Settings_SCThreshold()
+        public void Settings_SceneChangeThreshold()
         {
-            var settingWrong1 = new SCThreshold(120);
-            var setting = new SCThreshold(40);
+            var settingWrong1 = new SceneChangeThreshold(120);
+            var setting = new SceneChangeThreshold(40);
 
             Assert.Throws<InvalidOperationException>(() => { var s = settingWrong1.ToString(); });
             Assert.DoesNotThrow(() => { var s = setting.ToString(); });

--- a/Hudl.Ffmpeg/Hudl.Ffmpeg.csproj
+++ b/Hudl.Ffmpeg/Hudl.Ffmpeg.csproj
@@ -77,7 +77,7 @@
     <Compile Include="Settings\BaseTypes\BaseFormat.cs" />
     <Compile Include="Settings\AutoConvert.cs" />
     <Compile Include="Settings\Gop.cs" />
-    <Compile Include="Settings\SCThreshold.cs" />
+    <Compile Include="Settings\SceneChangeThreshold.cs" />
     <Compile Include="Settings\KeyIntMin.cs" />
     <Compile Include="Settings\MapMetadata.cs" />
     <Compile Include="Settings\MapChapters.cs" />

--- a/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
@@ -35,6 +35,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("1.16.0.0")]
-[assembly: AssemblyFileVersion("1.16.0.0")]
+[assembly: AssemblyInformationalVersion("1.17.0.0")]
+[assembly: AssemblyFileVersion("1.17.0.0")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/Hudl.Ffmpeg/Settings/SceneChangeThreshold.cs
+++ b/Hudl.Ffmpeg/Settings/SceneChangeThreshold.cs
@@ -10,11 +10,11 @@ namespace Hudl.Ffmpeg.Settings
 {
     [AppliesToResource(Type = typeof(IVideo))]
     [SettingsApplication(PreDeclaration = true, ResourceType = SettingsCollectionResourceType.Output)]
-    public class SCThreshold : BaseSetting
+    public class SceneChangeThreshold : BaseSetting
     {
         private const string SettingType = "-sc_threshold";
 
-        public SCThreshold(int size)
+        public SceneChangeThreshold(int size)
             : base(SettingType)
         {
             Size = size;
@@ -26,11 +26,11 @@ namespace Hudl.Ffmpeg.Settings
         {
             if (Size < 0)
             {
-                throw new InvalidOperationException("SCThreshold size must be greater than or equal to zero.");
+                throw new InvalidOperationException("SceneChangeThreshold size must be greater than or equal to zero.");
             }
             if (Size > 100)
             {
-                throw new InvalidOperationException("SCThreshold size must be less than or equal to 100.");
+                throw new InvalidOperationException("SceneChangeThreshold size must be less than or equal to 100.");
             }
 
             return string.Concat(Type, " ", Size);


### PR DESCRIPTION
This branch simply renames the 'SCThreshold' property to 'SceneChangeThreshold' so it's easier to understand.