### PR TITLE
Add additional container support

### DIFF
--- a/Hudl.FFmpeg.Core/Properties/AssemblyInfo.cs
+++ b/Hudl.FFmpeg.Core/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("3.3.0")]
-[assembly: AssemblyFileVersion("3.3.0")]
+[assembly: AssemblyInformationalVersion("3.4.0")]
+[assembly: AssemblyFileVersion("3.4.0")]
 [assembly: AssemblyVersion("3.0.0.0")]

--- a/Hudl.FFprobe/Properties/AssemblyInfo.cs
+++ b/Hudl.FFprobe/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("3.3.0")]
-[assembly: AssemblyFileVersion("3.3.0")]
+[assembly: AssemblyInformationalVersion("3.4.0")]
+[assembly: AssemblyFileVersion("3.4.0")]
 [assembly: AssemblyVersion("3.0.0.0")]

--- a/Hudl.Ffmpeg/Hudl.Ffmpeg.csproj
+++ b/Hudl.Ffmpeg/Hudl.Ffmpeg.csproj
@@ -100,6 +100,12 @@
     <Compile Include="Resources\BaseTypes\AudioStream.cs" />
     <Compile Include="Resources\BaseTypes\VideoStream.cs" />
     <Compile Include="Resources\Ismv.cs" />
+    <Compile Include="Resources\Avi.cs" />
+    <Compile Include="Resources\Nut.cs" />
+    <Compile Include="Resources\Ogg.cs" />
+    <Compile Include="Resources\Mkv.cs" />
+    <Compile Include="Resources\Vob.cs" />
+    <Compile Include="Resources\Mts.cs" />
     <Compile Include="Resources\Mov.cs" />
     <Compile Include="Resources\Ts.cs" />
     <Compile Include="Resources\Txt.cs" />

--- a/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
@@ -36,6 +36,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyInformationalVersion("3.3.0")]
-[assembly: AssemblyFileVersion("3.3.0")]
+[assembly: AssemblyInformationalVersion("3.4.0")]
+[assembly: AssemblyFileVersion("3.4.0")]
 [assembly: AssemblyVersion("3.0.0.0")]

--- a/Hudl.Ffmpeg/Resources/Avi.cs
+++ b/Hudl.Ffmpeg/Resources/Avi.cs
@@ -1,0 +1,23 @@
+﻿using Hudl.FFmpeg.Attributes;
+using Hudl.FFmpeg.Resources.BaseTypes;
+using Hudl.FFmpeg.Resources.Interfaces;
+
+namespace Hudl.FFmpeg.Resources
+{
+    [ContainsStream(Type = typeof(AudioStream))]
+    [ContainsStream(Type = typeof(VideoStream))]
+    public class Avi : BaseContainer
+    {
+        private const string FileFormat = ".avi";
+
+        public Avi()
+            : base(FileFormat)
+        {
+        }
+
+        protected override IContainer Clone()
+        {
+            return new Avi();
+        }
+    }
+}

--- a/Hudl.Ffmpeg/Resources/MTS.cs
+++ b/Hudl.Ffmpeg/Resources/MTS.cs
@@ -1,0 +1,23 @@
+﻿using Hudl.FFmpeg.Attributes;
+using Hudl.FFmpeg.Resources.BaseTypes;
+using Hudl.FFmpeg.Resources.Interfaces;
+
+namespace Hudl.FFmpeg.Resources
+{
+    [ContainsStream(Type = typeof(AudioStream))]
+    [ContainsStream(Type = typeof(VideoStream))]
+    public class Mts : BaseContainer
+    {
+        private const string FileFormat = ".mts";
+
+        public Mts()
+            : base(FileFormat)
+        {
+        }
+
+        protected override IContainer Clone()
+        {
+            return new Mts();
+        }
+    }
+}

--- a/Hudl.Ffmpeg/Resources/Mkv.cs
+++ b/Hudl.Ffmpeg/Resources/Mkv.cs
@@ -1,0 +1,23 @@
+﻿using Hudl.FFmpeg.Attributes;
+using Hudl.FFmpeg.Resources.BaseTypes;
+using Hudl.FFmpeg.Resources.Interfaces;
+
+namespace Hudl.FFmpeg.Resources
+{
+    [ContainsStream(Type = typeof(AudioStream))]
+    [ContainsStream(Type = typeof(VideoStream))]
+    public class Mkv : BaseContainer
+    {
+        private const string FileFormat = ".mkv";
+
+        public Mkv()
+            : base(FileFormat)
+        {
+        }
+
+        protected override IContainer Clone()
+        {
+            return new Mkv();
+        }
+    }
+}

--- a/Hudl.Ffmpeg/Resources/Nut.cs
+++ b/Hudl.Ffmpeg/Resources/Nut.cs
@@ -1,0 +1,23 @@
+﻿using Hudl.FFmpeg.Attributes;
+using Hudl.FFmpeg.Resources.BaseTypes;
+using Hudl.FFmpeg.Resources.Interfaces;
+
+namespace Hudl.FFmpeg.Resources
+{
+    [ContainsStream(Type = typeof(AudioStream))]
+    [ContainsStream(Type = typeof(VideoStream))]
+    public class Nut : BaseContainer
+    {
+        private const string FileFormat = ".nut";
+
+        public Nut()
+            : base(FileFormat)
+        {
+        }
+
+        protected override IContainer Clone()
+        {
+            return new Nut();
+        }
+    }
+}

--- a/Hudl.Ffmpeg/Resources/Ogg.cs
+++ b/Hudl.Ffmpeg/Resources/Ogg.cs
@@ -1,0 +1,23 @@
+﻿using Hudl.FFmpeg.Attributes;
+using Hudl.FFmpeg.Resources.BaseTypes;
+using Hudl.FFmpeg.Resources.Interfaces;
+
+namespace Hudl.FFmpeg.Resources
+{
+    [ContainsStream(Type = typeof(AudioStream))]
+    [ContainsStream(Type = typeof(VideoStream))]
+    public class Ogg : BaseContainer
+    {
+        private const string FileFormat = ".ogg";
+
+        public Ogg()
+            : base(FileFormat)
+        {
+        }
+
+        protected override IContainer Clone()
+        {
+            return new Ogg();
+        }
+    }
+}

--- a/Hudl.Ffmpeg/Resources/Vob.cs
+++ b/Hudl.Ffmpeg/Resources/Vob.cs
@@ -1,0 +1,23 @@
+﻿using Hudl.FFmpeg.Attributes;
+using Hudl.FFmpeg.Resources.BaseTypes;
+using Hudl.FFmpeg.Resources.Interfaces;
+
+namespace Hudl.FFmpeg.Resources
+{
+    [ContainsStream(Type = typeof(AudioStream))]
+    [ContainsStream(Type = typeof(VideoStream))]
+    public class Vob : BaseContainer
+    {
+        private const string FileFormat = ".vob";
+
+        public Vob()
+            : base(FileFormat)
+        {
+        }
+
+        protected override IContainer Clone()
+        {
+            return new Vob();
+        }
+    }
+}


### PR DESCRIPTION
We have added in additional containers supported by default in Hudl.FFmpeg
* ```*.avi```
* ```*.mts```
* ```*.mkv```
* ```*.nut```
* ```*.ogg```
* ```*.vob```