### PR TITLE
Add TIFF Resource Class

### DIFF
--- a/Hudl.Ffmpeg/Hudl.Ffmpeg.csproj
+++ b/Hudl.Ffmpeg/Hudl.Ffmpeg.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Filters\Crop.cs" />
     <Compile Include="Logging\LogUtility.cs" />
     <Compile Include="Resources\Ismv.cs" />
+    <Compile Include="Resources\Tiff.cs" />
     <Compile Include="Resources\Ts.cs" />
     <Compile Include="Resources\VideoTxt.cs" />
     <Compile Include="Settings\BaseTypes\BaseBitStreamFilter.cs" />

--- a/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
@@ -35,6 +35,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("1.18.0.0")]
-[assembly: AssemblyFileVersion("1.18.0.0")]
+[assembly: AssemblyInformationalVersion("1.19.0.0")]
+[assembly: AssemblyFileVersion("1.19.0.0")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/Hudl.Ffmpeg/Resources/Tiff.cs
+++ b/Hudl.Ffmpeg/Resources/Tiff.cs
@@ -1,0 +1,25 @@
+﻿using Hudl.Ffmpeg.Resources.BaseTypes;
+
+namespace Hudl.Ffmpeg.Resources
+{
+    public class Tiff : BaseImage
+    {
+        private const string FileFormat = ".tiff";
+
+        public Tiff() 
+            : base(FileFormat)
+        {
+        }
+       
+        protected override IResource InstanceOfMe()
+        {
+            return new Tiff
+            {
+                Id = Id,
+                Length = Length,
+                Name = Name,
+                Path = Path
+            };
+        }
+    }
+}


### PR DESCRIPTION
This allows files with a `.tiff` extension to be used without throwing an `InvalidOperationException`.