### PR TITLE
Scale Filter with String Expression

### DIFF
--- a/Hudl.Ffmpeg/Filters/Scale.cs
+++ b/Hudl.Ffmpeg/Filters/Scale.cs
@@ -47,11 +47,22 @@ namespace Hudl.Ffmpeg.Filters
 
             Dimensions = new Point(x, y);
         }
+        public Scale(string expression)
+            : this()
+        {
+            Expression = expression;
+        }
 
         public Point Dimensions { get; set; }
+        public string Expression { get; set; }
 
         public override string ToString()
         {
+            if (!string.IsNullOrWhiteSpace(Expression))
+            {
+                return string.Concat(Type, "=", Expression);
+            }
+
             if (Dimensions.X <= 0)
             {
                 throw new InvalidOperationException("Dimensions.X must be greater than zero for scaling.");

--- a/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
@@ -35,6 +35,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("1.19.0.0")]
-[assembly: AssemblyFileVersion("1.19.0.0")]
+[assembly: AssemblyInformationalVersion("1.21.0.0")]
+[assembly: AssemblyFileVersion("1.21.0.0")]
 [assembly: AssemblyVersion("1.0.0.0")]


### PR DESCRIPTION
This adds the ability to pass a string expression to the scale filter, which can be used for custom scaling such as `scale=iw*min(1280/iw\,720/ih):ih*min(1280/iw\,720/ih)`.

Version number is intentionally incremented by two as I plan to merge this after #37.