### PR TITLE
Add More Image Resource Types

### DIFF
--- a/Hudl.Ffmpeg/Hudl.Ffmpeg.csproj
+++ b/Hudl.Ffmpeg/Hudl.Ffmpeg.csproj
@@ -72,7 +72,17 @@
     <Compile Include="Filters\Fps.cs" />
     <Compile Include="Filters\Crop.cs" />
     <Compile Include="Logging\LogUtility.cs" />
+    <Compile Include="Resources\Xwd.cs" />
+    <Compile Include="Resources\Tga.cs" />
+    <Compile Include="Resources\Sgi.cs" />
+    <Compile Include="Resources\Ppm.cs" />
+    <Compile Include="Resources\Pgm.cs" />
+    <Compile Include="Resources\Pcx.cs" />
+    <Compile Include="Resources\Pbm.cs" />
+    <Compile Include="Resources\Bmp.cs" />
+    <Compile Include="Resources\Xbm.cs" />
     <Compile Include="Resources\Ismv.cs" />
+    <Compile Include="Resources\Gif.cs" />
     <Compile Include="Resources\Tiff.cs" />
     <Compile Include="Resources\Ts.cs" />
     <Compile Include="Resources\VideoTxt.cs" />

--- a/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
@@ -35,6 +35,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("1.21.0.0")]
-[assembly: AssemblyFileVersion("1.21.0.0")]
+[assembly: AssemblyInformationalVersion("1.22.0.0")]
+[assembly: AssemblyFileVersion("1.22.0.0")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/Hudl.Ffmpeg/Resources/Bmp.cs
+++ b/Hudl.Ffmpeg/Resources/Bmp.cs
@@ -1,0 +1,25 @@
+﻿using Hudl.Ffmpeg.Resources.BaseTypes;
+
+namespace Hudl.Ffmpeg.Resources
+{
+    public class Bmp : BaseImage
+    {
+        private const string FileFormat = ".bmp";
+
+        public Bmp() 
+            : base(FileFormat)
+        {
+        }
+
+        protected override IResource InstanceOfMe()
+        {
+            return new Bmp
+                {
+                    Id = Id, 
+                    Length = Length,
+                    Name = Name,
+                    Path = Path
+                };
+        }
+    }
+}

--- a/Hudl.Ffmpeg/Resources/Gif.cs
+++ b/Hudl.Ffmpeg/Resources/Gif.cs
@@ -1,0 +1,25 @@
+﻿using Hudl.Ffmpeg.Resources.BaseTypes;
+
+namespace Hudl.Ffmpeg.Resources
+{
+    public class Gif : BaseImage
+    {
+        private const string FileFormat = ".gif";
+
+        public Gif() 
+            : base(FileFormat)
+        {
+        }
+
+        protected override IResource InstanceOfMe()
+        {
+            return new Gif
+                {
+                    Id = Id, 
+                    Length = Length,
+                    Name = Name,
+                    Path = Path
+                };
+        }
+    }
+}

--- a/Hudl.Ffmpeg/Resources/Pbm.cs
+++ b/Hudl.Ffmpeg/Resources/Pbm.cs
@@ -1,0 +1,25 @@
+﻿using Hudl.Ffmpeg.Resources.BaseTypes;
+
+namespace Hudl.Ffmpeg.Resources
+{
+    public class Pbm : BaseImage
+    {
+        private const string FileFormat = ".pbm";
+
+        public Pbm() 
+            : base(FileFormat)
+        {
+        }
+
+        protected override IResource InstanceOfMe()
+        {
+            return new Pbm
+                {
+                    Id = Id, 
+                    Length = Length,
+                    Name = Name,
+                    Path = Path
+                };
+        }
+    }
+}

--- a/Hudl.Ffmpeg/Resources/Pcx.cs
+++ b/Hudl.Ffmpeg/Resources/Pcx.cs
@@ -1,0 +1,25 @@
+﻿using Hudl.Ffmpeg.Resources.BaseTypes;
+
+namespace Hudl.Ffmpeg.Resources
+{
+    public class Pcx : BaseImage
+    {
+        private const string FileFormat = ".pcx";
+
+        public Pcx() 
+            : base(FileFormat)
+        {
+        }
+
+        protected override IResource InstanceOfMe()
+        {
+            return new Pcx
+                {
+                    Id = Id, 
+                    Length = Length,
+                    Name = Name,
+                    Path = Path
+                };
+        }
+    }
+}

--- a/Hudl.Ffmpeg/Resources/Pgm.cs
+++ b/Hudl.Ffmpeg/Resources/Pgm.cs
@@ -1,0 +1,25 @@
+﻿using Hudl.Ffmpeg.Resources.BaseTypes;
+
+namespace Hudl.Ffmpeg.Resources
+{
+    public class Pgm : BaseImage
+    {
+        private const string FileFormat = ".pgm";
+
+        public Pgm() 
+            : base(FileFormat)
+        {
+        }
+
+        protected override IResource InstanceOfMe()
+        {
+            return new Pgm
+                {
+                    Id = Id, 
+                    Length = Length,
+                    Name = Name,
+                    Path = Path
+                };
+        }
+    }
+}

--- a/Hudl.Ffmpeg/Resources/Ppm.cs
+++ b/Hudl.Ffmpeg/Resources/Ppm.cs
@@ -1,0 +1,25 @@
+﻿using Hudl.Ffmpeg.Resources.BaseTypes;
+
+namespace Hudl.Ffmpeg.Resources
+{
+    public class Ppm : BaseImage
+    {
+        private const string FileFormat = ".ppm";
+
+        public Ppm() 
+            : base(FileFormat)
+        {
+        }
+
+        protected override IResource InstanceOfMe()
+        {
+            return new Ppm
+                {
+                    Id = Id, 
+                    Length = Length,
+                    Name = Name,
+                    Path = Path
+                };
+        }
+    }
+}

--- a/Hudl.Ffmpeg/Resources/Sgi.cs
+++ b/Hudl.Ffmpeg/Resources/Sgi.cs
@@ -1,0 +1,25 @@
+﻿using Hudl.Ffmpeg.Resources.BaseTypes;
+
+namespace Hudl.Ffmpeg.Resources
+{
+    public class Sgi : BaseImage
+    {
+        private const string FileFormat = ".sgi";
+
+        public Sgi() 
+            : base(FileFormat)
+        {
+        }
+
+        protected override IResource InstanceOfMe()
+        {
+            return new Sgi
+                {
+                    Id = Id, 
+                    Length = Length,
+                    Name = Name,
+                    Path = Path
+                };
+        }
+    }
+}

--- a/Hudl.Ffmpeg/Resources/Tga.cs
+++ b/Hudl.Ffmpeg/Resources/Tga.cs
@@ -1,0 +1,25 @@
+﻿using Hudl.Ffmpeg.Resources.BaseTypes;
+
+namespace Hudl.Ffmpeg.Resources
+{
+    public class Tga : BaseImage
+    {
+        private const string FileFormat = ".tga";
+
+        public Tga() 
+            : base(FileFormat)
+        {
+        }
+
+        protected override IResource InstanceOfMe()
+        {
+            return new Tga
+                {
+                    Id = Id, 
+                    Length = Length,
+                    Name = Name,
+                    Path = Path
+                };
+        }
+    }
+}

--- a/Hudl.Ffmpeg/Resources/Xbm.cs
+++ b/Hudl.Ffmpeg/Resources/Xbm.cs
@@ -1,0 +1,25 @@
+﻿using Hudl.Ffmpeg.Resources.BaseTypes;
+
+namespace Hudl.Ffmpeg.Resources
+{
+    public class Xbm : BaseImage
+    {
+        private const string FileFormat = ".xbm";
+
+        public Xbm() 
+            : base(FileFormat)
+        {
+        }
+
+        protected override IResource InstanceOfMe()
+        {
+            return new Xbm
+                {
+                    Id = Id, 
+                    Length = Length,
+                    Name = Name,
+                    Path = Path
+                };
+        }
+    }
+}

--- a/Hudl.Ffmpeg/Resources/Xwd.cs
+++ b/Hudl.Ffmpeg/Resources/Xwd.cs
@@ -1,0 +1,25 @@
+﻿using Hudl.Ffmpeg.Resources.BaseTypes;
+
+namespace Hudl.Ffmpeg.Resources
+{
+    public class Xwd : BaseImage
+    {
+        private const string FileFormat = ".xwd";
+
+        public Xwd() 
+            : base(FileFormat)
+        {
+        }
+
+        protected override IResource InstanceOfMe()
+        {
+            return new Xwd
+                {
+                    Id = Id, 
+                    Length = Length,
+                    Name = Name,
+                    Path = Path
+                };
+        }
+    }
+}


### PR DESCRIPTION
I specifically set out to add BMP and GIF, but also added any image format from [this list](https://www.ffmpeg.org/general.html#Image-Formats) for which I could generate a test file using gimp and have it immediately work with FFMPEG version N-63716-g763e714.