### PR TITLE
Version Bump to 1.22.1.0

### DIFF
--- a/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
@@ -35,6 +35,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("1.23.0.0")]
-[assembly: AssemblyFileVersion("1.23.0.0")]
+[assembly: AssemblyInformationalVersion("1.22.1.0")]
+[assembly: AssemblyFileVersion("1.22.1.0")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
@@ -35,6 +35,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("1.22.0.0")]
-[assembly: AssemblyFileVersion("1.22.0.0")]
+[assembly: AssemblyInformationalVersion("1.23.0.0")]
+[assembly: AssemblyFileVersion("1.23.0.0")]
 [assembly: AssemblyVersion("1.0.0.0")]


### PR DESCRIPTION
There was a stray NuGet package for version 1.22.0.0 that was not recorded in version control. This will enable pulling the latest Hudl.Ffmpeg v1 without having to clear the NuGet cache if 1.22.0.0 was pulled earlier.