### PR TITLE
Update master_1.0 to use AnyCPU

### DIFF
--- a/Hudl.Ffmpeg.Tests/Hudl.Ffmpeg.Tests.csproj
+++ b/Hudl.Ffmpeg.Tests/Hudl.Ffmpeg.Tests.csproj
@@ -25,7 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -101,10 +101,8 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  
-  <UsingTask AssemblyFile="../packages/xunit.1.9.2/lib/net20/xunit.runner.msbuild.dll" TaskName="Xunit.Runner.MSBuild.xunit"/>
-
+  <UsingTask AssemblyFile="../packages/xunit.1.9.2/lib/net20/xunit.runner.msbuild.dll" TaskName="Xunit.Runner.MSBuild.xunit" />
   <Target Name="UnitTest">
-    <xunit Assembly="bin\Release\Hudl.Ffmpeg.Tests.dll"/>
+    <xunit Assembly="bin\Release\Hudl.Ffmpeg.Tests.dll" />
   </Target>
 </Project>

--- a/Hudl.Ffmpeg/Hudl.Ffmpeg.csproj
+++ b/Hudl.Ffmpeg/Hudl.Ffmpeg.csproj
@@ -23,7 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.Ffmpeg/Properties/AssemblyInfo.cs
@@ -35,6 +35,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("1.22.1.0")]
-[assembly: AssemblyFileVersion("1.22.1.0")]
+[assembly: AssemblyInformationalVersion("1.22.2.0")]
+[assembly: AssemblyFileVersion("1.22.2.0")]
 [assembly: AssemblyVersion("1.0.0.0")]


### PR DESCRIPTION
The existing Lifeguard tests generate warnings (and fail to run) due to the Hudl.Ffmpeg reference not being compiled for 64bit cpus. 

This PR changes the targets to allow 64bit versions to be generated, which will allow the tests to run in Lifeguard.
