### PR TITLE
Allow SampleRate setting for any resource type

### DIFF
--- a/Hudl.Ffmpeg.Tests/Setting/SettingCollectionTests.cs
+++ b/Hudl.Ffmpeg.Tests/Setting/SettingCollectionTests.cs
@@ -35,6 +35,13 @@ namespace Hudl.FFmpeg.Tests.Setting
         {
             Assert.Throws<ArgumentException>(() => SettingsCollection.ForOutput(new StartAt(1))); 
         }
+        
+        [Fact]
+        public void SettingsCollection_ForAny()
+        {
+            Assert.DoesNotThrow(() => SettingsCollection.ForOutput(new SampleRate(44100)));
+            Assert.DoesNotThrow(() => SettingsCollection.ForInput(new SampleRate(44100)));
+        }
 
         [Fact]
         public void SettingsCollection_AllowMultiple()

--- a/Hudl.Ffmpeg/Common/Validate.cs
+++ b/Hudl.Ffmpeg/Common/Validate.cs
@@ -30,7 +30,8 @@ namespace Hudl.FFmpeg.Common
         public static bool IsSettingFor<TSetting>(TSetting item, SettingsCollectionResourceType type)
             where TSetting : ISetting
         {
-            return type == item.GetResourceType();
+            return item.GetResourceType() == SettingsCollectionResourceType.Any ||
+                type == item.GetResourceType();
         }
 
     }

--- a/Hudl.Ffmpeg/Settings/SampleRate.cs
+++ b/Hudl.Ffmpeg/Settings/SampleRate.cs
@@ -9,7 +9,7 @@ using Hudl.FFmpeg.Settings.Interfaces;
 namespace Hudl.FFmpeg.Settings
 {
     [ForStream(Type = typeof(AudioStream))]
-    [Setting(Name = "ar")]
+    [Setting(Name = "ar", ResourceType = SettingsCollectionResourceType.Any)]
     public class SampleRate : ISetting
     {
         public SampleRate(double rate)


### PR DESCRIPTION
Set the allowed ResourceType for the Sample-Rate setting to ```Any```.
Example Use-Case:
```ffmpeg -i "input.pcm" -f u16le -ar 44100 -ac 2 -acodec libmp3lame "./output.mp3"```
to encode raw pcm-data with mp3.