### PR TITLE
Hudl.FFmpeg v3.6

### DIFF
--- a/Hudl.FFprobe/Serialization/Converters/StreamConverter.cs
+++ b/Hudl.FFprobe/Serialization/Converters/StreamConverter.cs
@@ -23,7 +23,12 @@ namespace Hudl.FFprobe.Serialization.Converters
                 return new VideoStreamMetadata();
             }
              
-            return new AudioStreamMetadata();
+            if (string.Equals(codecType, CodecTypes.Audio.ToString(), StringComparison.InvariantCultureIgnoreCase))
+            {
+                return new AudioStreamMetadata();
+            }
+
+            return null; 
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
@@ -41,6 +46,11 @@ namespace Hudl.FFprobe.Serialization.Converters
 
                 var targetObject = jsonToken.Value<JObject>();
                 var targetType = Create(objectType, targetObject);
+                if (targetType == null)
+                {
+                    //unsupported type, dont wanna worry about it.
+                    continue;
+                }
 
                 serializer.Populate(targetObject.CreateReader(), targetType);
 

--- a/Hudl.Ffmpeg/Hudl.Ffmpeg.nuspec
+++ b/Hudl.Ffmpeg/Hudl.Ffmpeg.nuspec
@@ -5,8 +5,8 @@
 	<version>$version$</version>
 	<authors>$author$</authors>
 	<description>$description$</description>
-  <tags>video audio codec ffmpeg framework</tags>
-  <projectUrl>https://github.com/hudl/HudlFfmpeg</projectUrl>
+    <tags>video audio codec ffmpeg framework</tags>
+    <projectUrl>https://github.com/hudl/HudlFfmpeg</projectUrl>
 	<iconUrl>https://raw.githubusercontent.com/hudl/HudlFfmpeg/master/hudl.png</iconUrl>
   </metadata>
   <files>

--- a/Hudl.Ffmpeg/Hudl.Ffmpeg.nuspec
+++ b/Hudl.Ffmpeg/Hudl.Ffmpeg.nuspec
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
-	<id>$id$</id>
-	<version>$version$</version>
-	<authors>$author$</authors>
-	<description>$description$</description>
+    <id>$id$</id>
+    <version>$version$</version>
+    <authors>$author$</authors>
+    <description>$description$</description>
     <tags>video audio codec ffmpeg framework</tags>
     <projectUrl>https://github.com/hudl/HudlFfmpeg</projectUrl>
-	<iconUrl>https://raw.githubusercontent.com/hudl/HudlFfmpeg/master/hudl.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/hudl/HudlFfmpeg/master/hudl.png</iconUrl>
   </metadata>
   <files>
     <file src="bin\Release\$id$.dll" target="lib\net45"/>        

--- a/Hudl.Ffmpeg/Hudl.Ffmpeg.nuspec
+++ b/Hudl.Ffmpeg/Hudl.Ffmpeg.nuspec
@@ -5,6 +5,8 @@
 	<version>$version$</version>
 	<authors>$author$</authors>
 	<description>$description$</description>
+  <tags>video audio codec ffmpeg framework</tags>
+  <projectUrl>https://github.com/hudl/HudlFfmpeg</projectUrl>
 	<iconUrl>https://raw.githubusercontent.com/hudl/HudlFfmpeg/master/hudl.png</iconUrl>
   </metadata>
   <files>


### PR DESCRIPTION
## Changes 
* updated nuspec with tags and project site url
* ffprobe bug fixes: ignore unsupported codec types 