### PR TITLE
Change XUnit Runner version to run with an older version of nuget

### DIFF
--- a/Hudl.Ffmpeg.Tests/Hudl.Ffmpeg.Tests.csproj
+++ b/Hudl.Ffmpeg.Tests/Hudl.Ffmpeg.Tests.csproj
@@ -26,7 +26,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/Hudl.Ffmpeg.Tests/packages.config
+++ b/Hudl.Ffmpeg.Tests/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="OpenCover" version="4.6.519" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net40" />
-  <package id="xunit.runner.console" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.console" version="2.0.0" targetFramework="net45" />
   <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net40" />
 </packages>

--- a/runCoverageReport.ps1
+++ b/runCoverageReport.ps1
@@ -1,0 +1,2 @@
+set-variable -name tests -value (ls *.Tests/bin/Release/*.Tests.dll | % FullName)
+packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register -target:"packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe" "-targetargs:$tests -noshadow -parallel none" "-filter:+[Hudl.FFmpeg*]* +[Hudl.FFprobe]*" -hideskipped:All -excludebyattribute:*.ExcludeFromCodeCoverage* -output:Hudl.FFmpeg_Coverage.xml

--- a/uploadToCodecov.ps1
+++ b/uploadToCodecov.ps1
@@ -1,0 +1,1 @@
+codecov -t $env:codecovApiKey -f Hudl.FFmpeg_Coverage.xml


### PR DESCRIPTION
Updating the xunit.console.runner to work with an older version of nuget.exe. 