### PR TITLE
Implement timeout functionality and process monitoring

### DIFF
--- a/Hudl.FFmpeg.Core/Command/BaseTypes/ICommand.cs
+++ b/Hudl.FFmpeg.Core/Command/BaseTypes/ICommand.cs
@@ -8,11 +8,11 @@ namespace Hudl.FFmpeg.Command.BaseTypes
 
         Action<ICommandFactory, ICommand, bool> PostExecutionAction { get; set; }
 
-        ICommandProcessor ExecuteWith<TProcessorType, TBuilderType>()
+        ICommandProcessor ExecuteWith<TProcessorType, TBuilderType>(int? timeoutMilliseconds)
             where TProcessorType : class, ICommandProcessor, new()
             where TBuilderType : class, ICommandBuilder, new();
 
-        ICommandProcessor ExecuteWith<TProcessorType, TBuilderType>(TProcessorType commandProcessor)
+        ICommandProcessor ExecuteWith<TProcessorType, TBuilderType>(TProcessorType commandProcessor, int? timeoutMilliseconds)
             where TProcessorType : class, ICommandProcessor
             where TBuilderType : class, ICommandBuilder, new();
     }

--- a/Hudl.FFmpeg.Core/Command/BaseTypes/ICommand.cs
+++ b/Hudl.FFmpeg.Core/Command/BaseTypes/ICommand.cs
@@ -8,6 +8,10 @@ namespace Hudl.FFmpeg.Command.BaseTypes
 
         Action<ICommandFactory, ICommand, bool> PostExecutionAction { get; set; }
 
+        ICommandProcessor ExecuteWith<TProcessorType, TBuilderType>()
+            where TProcessorType : class, ICommandProcessor, new()
+            where TBuilderType : class, ICommandBuilder, new();
+
         ICommandProcessor ExecuteWith<TProcessorType, TBuilderType>(int? timeoutMilliseconds)
             where TProcessorType : class, ICommandProcessor, new()
             where TBuilderType : class, ICommandBuilder, new();

--- a/Hudl.FFmpeg.Core/Command/BaseTypes/ICommandProcessor.cs
+++ b/Hudl.FFmpeg.Core/Command/BaseTypes/ICommandProcessor.cs
@@ -35,7 +35,7 @@ namespace Hudl.FFmpeg.Command.BaseTypes
         /// <summary>
         /// processes the given command string against the processor engine
         /// </summary>
-        bool Send(string command);
+        bool Send(string command, int? timeoutMilliseconds);
 
        
     }

--- a/Hudl.FFmpeg.Core/Command/BaseTypes/ICommandProcessor.cs
+++ b/Hudl.FFmpeg.Core/Command/BaseTypes/ICommandProcessor.cs
@@ -35,8 +35,11 @@ namespace Hudl.FFmpeg.Command.BaseTypes
         /// <summary>
         /// processes the given command string against the processor engine
         /// </summary>
-        bool Send(string command, int? timeoutMilliseconds);
+        bool Send(string command);
 
-       
+        /// <summary>
+        /// processes the given command string against the processor engine
+        /// </summary>
+        bool Send(string command, int? timeoutMilliseconds);
     }
 }

--- a/Hudl.FFmpeg.Core/Command/Models/FFcommandBase.cs
+++ b/Hudl.FFmpeg.Core/Command/Models/FFcommandBase.cs
@@ -4,9 +4,9 @@ using Hudl.FFmpeg.Exceptions;
 
 namespace Hudl.FFmpeg.Command.Models
 {
-    public abstract class FFcommandBase : ICommand
+    public abstract class FFCommandBase : ICommand
     {
-        protected FFcommandBase()
+        protected FFCommandBase()
         {
             PreExecutionAction = EmptyOperation;
             PostExecutionAction = EmptyOperation;
@@ -23,6 +23,13 @@ namespace Hudl.FFmpeg.Command.Models
         public Action<ICommandFactory, ICommand, ICommandProcessor> OnSuccessAction { get; set; }
 
         public Action<ICommandFactory, ICommand, ICommandProcessor> OnErrorAction { get; set; }
+
+        public ICommandProcessor ExecuteWith<TProcessorType, TBuilderType>()
+            where TProcessorType : class, ICommandProcessor, new()
+            where TBuilderType : class, ICommandBuilder, new()
+        {
+            return ExecuteWith<TProcessorType, TBuilderType>(null);
+        }
 
         public ICommandProcessor ExecuteWith<TProcessorType, TBuilderType>(int? timeoutMilliseconds)
             where TProcessorType : class, ICommandProcessor, new()

--- a/Hudl.FFmpeg.Core/Command/Models/FFcommandBase.cs
+++ b/Hudl.FFmpeg.Core/Command/Models/FFcommandBase.cs
@@ -24,7 +24,7 @@ namespace Hudl.FFmpeg.Command.Models
 
         public Action<ICommandFactory, ICommand, ICommandProcessor> OnErrorAction { get; set; }
 
-        public ICommandProcessor ExecuteWith<TProcessorType, TBuilderType>()
+        public ICommandProcessor ExecuteWith<TProcessorType, TBuilderType>(int? timeoutMilliseconds)
             where TProcessorType : class, ICommandProcessor, new()
             where TBuilderType : class, ICommandBuilder, new()
         {
@@ -35,7 +35,7 @@ namespace Hudl.FFmpeg.Command.Models
                 throw new FFmpegRenderingException(commandProcessor.Error);
             }
 
-            var returnType = ExecuteWith<TProcessorType, TBuilderType>(commandProcessor);
+            var returnType = ExecuteWith<TProcessorType, TBuilderType>(commandProcessor, timeoutMilliseconds);
 
             if (!commandProcessor.Close())
             {
@@ -45,7 +45,7 @@ namespace Hudl.FFmpeg.Command.Models
             return returnType;
         }
 
-        public ICommandProcessor ExecuteWith<TProcessorType, TBuilderType>(TProcessorType commandProcessor)
+        public ICommandProcessor ExecuteWith<TProcessorType, TBuilderType>(TProcessorType commandProcessor, int? timeoutMilliseconds)
             where TProcessorType : class, ICommandProcessor
             where TBuilderType : class, ICommandBuilder, new()
         {
@@ -59,7 +59,7 @@ namespace Hudl.FFmpeg.Command.Models
 
             PreExecutionAction(Owner, this, true);
 
-            if (!commandProcessor.Send(commandBuilder.ToString()))
+            if (!commandProcessor.Send(commandBuilder.ToString(), timeoutMilliseconds))
             {
                 PostExecutionAction(Owner, this, false);
 

--- a/Hudl.FFmpeg.Core/Command/Models/FFcommandBuilderBase.cs
+++ b/Hudl.FFmpeg.Core/Command/Models/FFcommandBuilderBase.cs
@@ -2,11 +2,11 @@
 
 namespace Hudl.FFmpeg.Command.Models
 {
-    public abstract class FFcommandBuilderBase 
+    public abstract class FFCommandBuilderBase 
     {
         protected readonly StringBuilder BuilderBase;
 
-        protected FFcommandBuilderBase()
+        protected FFCommandBuilderBase()
         {
             BuilderBase = new StringBuilder(100);            
         }

--- a/Hudl.FFmpeg.Core/Command/StreamReaders/BaseStandardStreamReader.cs
+++ b/Hudl.FFmpeg.Core/Command/StreamReaders/BaseStandardStreamReader.cs
@@ -1,0 +1,98 @@
+﻿using Hudl.FFmpeg.Logging;
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+
+namespace Hudl.FFmpeg.Command.StreamReaders
+{
+    public abstract class BaseStandardStreamReader
+    {
+        private static readonly LogUtility Log = LogUtility.GetLogger(typeof(BaseStandardStreamReader));
+        private const int OutputBuilderLimit = 10000;
+
+        protected BaseStandardStreamReader(Process processToListenTo)
+        {
+            OutputBuilder = new StringBuilder();
+            ProcessToListenTo = processToListenTo;
+            _stopSignal = new ManualResetEvent(false);
+        }
+
+        protected Thread MonitoringThread;
+        protected StringBuilder OutputBuilder;
+        protected readonly Process ProcessToListenTo;
+        protected volatile bool _stopped;
+        protected ManualResetEvent _stopSignal;
+
+        public string LastLineReceived { get; set; }
+
+        public void Listen()
+        {
+            //workaround for a bug in the mono process when attempting to read async from console output events
+            // - link http://mono.1490590.n4.nabble.com/System-Diagnostic-Process-and-event-handlers-td3246096.html
+            if (ResourceManagement.IsMonoRuntime())
+            {
+                ListenAsThread();
+            }
+            else
+            {
+                ListenAsAsync();
+            }
+        }
+        protected abstract void ListenAsAsync();
+        protected abstract void ListenAsThread();
+
+        public void Stop()
+        {
+            _stopped = true;
+            _stopSignal.WaitOne(1000);
+            if (ResourceManagement.IsMonoRuntime())
+            {
+                try
+                {
+                    if (MonitoringThread.ThreadState != System.Threading.ThreadState.Stopped)
+                    {
+                        MonitoringThread.Abort();
+                    }
+                }
+                catch (Exception e)
+                {
+                    Log.Error("Unable to abort the monitoring thread", e);
+                }
+            }
+        }
+
+        private void HandleDataReceived(string data)
+        {
+            if (!string.IsNullOrWhiteSpace(data))
+            {
+                LastLineReceived = data;
+            }
+
+            //there is no specific reason behind this number other than, it seems like a pretty good number baseline. 
+            //ultimately ffmpeg can blow up the standard output/error stream with logs. we dont want to create
+            //an OOM exception. so we will trash and reset.
+            if (OutputBuilder.Length > OutputBuilderLimit)
+            {
+                var newBuilder = new StringBuilder(OutputBuilderLimit);
+                newBuilder.Append(OutputBuilder.ToString(), OutputBuilderLimit / 2, OutputBuilderLimit / 2);
+                OutputBuilder = newBuilder;
+            }
+
+            OutputBuilder.AppendLine(data);
+        }
+        protected void HandleDataReceivedAsAsync(object sender, DataReceivedEventArgs dataReceivedEventArgs)
+        {
+            HandleDataReceived(dataReceivedEventArgs.Data);
+        }
+        protected void HandleDataReceivedAsThread(string data)
+        {
+            HandleDataReceived(data);
+        }
+       
+        public override string ToString()
+        {
+            return OutputBuilder.ToString();
+        }
+    }
+}

--- a/Hudl.FFmpeg.Core/Command/StreamReaders/StandardErrorAsyncStreamReader.cs
+++ b/Hudl.FFmpeg.Core/Command/StreamReaders/StandardErrorAsyncStreamReader.cs
@@ -1,0 +1,54 @@
+﻿using System.Diagnostics;
+using System.Threading;
+
+namespace Hudl.FFmpeg.Command.StreamReaders
+{
+    public class StandardErrorAsyncStreamReader : BaseStandardStreamReader
+    {
+        private StandardErrorAsyncStreamReader(Process processToListenTo)
+            : base(processToListenTo)
+        {
+            ProcessToListenTo.StartInfo.RedirectStandardError = true;
+            if (!ResourceManagement.IsMonoRuntime())
+            {
+                ProcessToListenTo.ErrorDataReceived += HandleDataReceivedAsAsync;
+            }
+        }
+
+        public static StandardErrorAsyncStreamReader AttachReader(Process processToListenTo)
+        {
+            return new StandardErrorAsyncStreamReader(processToListenTo);
+        }
+
+        protected override void ListenAsAsync()
+        {
+            ProcessToListenTo.BeginErrorReadLine();
+        }
+
+        protected override void ListenAsThread()
+        {
+            MonitoringThread = new Thread(AsyncStdErrorMonitor);
+            MonitoringThread.Start();
+        }
+
+        private void AsyncStdErrorMonitor()
+        {
+            try
+            {
+                do
+                {
+                    string line = ProcessToListenTo.StandardError.ReadLine();
+                    if (line != null)
+                    {
+                        HandleDataReceivedAsThread(line);
+                    }
+                }
+                while (!_stopped && !ProcessToListenTo.HasExited);
+                _stopSignal.Set();
+            }
+            catch
+            { }
+        }
+    }
+
+}

--- a/Hudl.FFmpeg.Core/Command/StreamReaders/StandardOutputAsyncStreamReader.cs
+++ b/Hudl.FFmpeg.Core/Command/StreamReaders/StandardOutputAsyncStreamReader.cs
@@ -1,0 +1,54 @@
+﻿using System.Diagnostics;
+using System.Threading;
+
+namespace Hudl.FFmpeg.Command.StreamReaders
+{
+    public class StandardOutputAsyncStreamReader : BaseStandardStreamReader
+    {
+        private StandardOutputAsyncStreamReader(Process processToListenTo)
+            : base(processToListenTo)
+        {
+            ProcessToListenTo.StartInfo.RedirectStandardOutput = true;
+            if (!ResourceManagement.IsMonoRuntime())
+            {
+                ProcessToListenTo.ErrorDataReceived += HandleDataReceivedAsAsync;
+            }
+        }
+
+        public static StandardOutputAsyncStreamReader AttachReader(Process processToListenTo)
+        {
+            return new StandardOutputAsyncStreamReader(processToListenTo);
+        }
+
+        protected override void ListenAsAsync()
+        {
+            ProcessToListenTo.BeginErrorReadLine();
+        }
+
+        protected override void ListenAsThread()
+        {
+            MonitoringThread = new Thread(AsyncStdErrorMonitor);
+            MonitoringThread.Start();
+        }
+
+        private void AsyncStdErrorMonitor()
+        {
+            try
+            {
+                do
+                {
+                    string line = ProcessToListenTo.StandardError.ReadLine();
+                    if (line != null)
+                    {
+                        HandleDataReceivedAsThread(line);
+                    }
+                }
+                while (!_stopped && !ProcessToListenTo.HasExited);
+                _stopSignal.Set();
+            }
+            catch
+            { }
+        }
+    }
+
+}

--- a/Hudl.FFmpeg.Core/Exceptions/FfmpegTimeoutException.cs
+++ b/Hudl.FFmpeg.Core/Exceptions/FfmpegTimeoutException.cs
@@ -11,14 +11,10 @@ namespace Hudl.FFmpeg.Exceptions
             : base("FFmpeg timed out during processing")
         {
             base.Data["Arguments"] = arguments;
-            base.Data["ErrorOutput"] = errorOutput;
 
             Arguments = arguments;
-            ErrorOutput = errorOutput; 
         }
 
         public string Arguments { get; private set; }
-
-        public string ErrorOutput { get; private set; }
     }
 }

--- a/Hudl.FFmpeg.Core/Exceptions/FfmpegTimeoutException.cs
+++ b/Hudl.FFmpeg.Core/Exceptions/FfmpegTimeoutException.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace Hudl.FFmpeg.Exceptions
+{
+    /// <summary>
+    /// exception that is thrown when FFmpeg commands have passed the timeout period
+    /// </summary>
+    public class FFmpegTimeoutException : Exception
+    {
+        public FFmpegTimeoutException(string arguments)
+            : base("FFmpeg timed out during processing")
+        {
+            base.Data["Arguments"] = arguments;
+            base.Data["ErrorOutput"] = errorOutput;
+
+            Arguments = arguments;
+            ErrorOutput = errorOutput; 
+        }
+
+        public string Arguments { get; private set; }
+
+        public string ErrorOutput { get; private set; }
+    }
+}

--- a/Hudl.FFmpeg.Core/Extensions/ProcessExtensions.cs
+++ b/Hudl.FFmpeg.Core/Extensions/ProcessExtensions.cs
@@ -44,7 +44,7 @@ namespace Hudl.FFmpeg.Extensions
         }
         public static bool WaitForProcessStop(this Process process, int? timeoutMilliseconds)
         {
-            var processTimeout = TimeSpan.FromMilliseconds(timeoutMilliseconds ?? 5000);
+            var processTimeout = TimeSpan.FromMilliseconds(timeoutMilliseconds ?? 0);
             return process.WaitForProcessStop(processTimeout);
         }
         public static bool WaitForProcessStop(this Process process, TimeSpan processTimeout)

--- a/Hudl.FFmpeg.Core/Extensions/ProcessExtensions.cs
+++ b/Hudl.FFmpeg.Core/Extensions/ProcessExtensions.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Hudl.FFmpeg.Extensions
+{
+    public static class ProcessExtensions
+    {
+        public static bool WaitForProcessStart(this Process process)
+        {
+            return process.WaitForProcessStart(null);
+        }
+        public static bool WaitForProcessStart(this Process process, int? timeoutMilliseconds)
+        {
+            var processTimeout = TimeSpan.FromMilliseconds(timeoutMilliseconds ?? 5000);
+            return process.WaitForProcessStart(processTimeout);
+        }
+        public static bool WaitForProcessStart(this Process process, TimeSpan processTimeout)
+        {
+            var processStopwatch = Stopwatch.StartNew();
+            var isProcessRunning = false;
+
+            while (processStopwatch.ElapsedMilliseconds <= processTimeout.TotalMilliseconds && !isProcessRunning)
+            {
+                //give a little bit of breathing room here....
+                Thread.Sleep(20.Milliseconds());
+
+                try
+                {
+                    isProcessRunning = (process != null && !process.HasExited && process.Id != 0);
+                }
+                catch
+                {
+                    isProcessRunning = false;
+                }
+            }
+
+            return isProcessRunning;
+        }
+
+        public static bool WaitForProcessStop(this Process process)
+        {
+            return process.WaitForProcessStop(null);
+        }
+        public static bool WaitForProcessStop(this Process process, int? timeoutMilliseconds)
+        {
+            var processTimeout = TimeSpan.FromMilliseconds(timeoutMilliseconds ?? 5000);
+            return process.WaitForProcessStop(processTimeout);
+        }
+        public static bool WaitForProcessStop(this Process process, TimeSpan processTimeout)
+        {
+            var processStopwatch = Stopwatch.StartNew();
+
+            while (!process.HasExited)
+            {
+                Thread.Sleep(1.Seconds());
+
+                if (processTimeout.TotalMilliseconds > 0 && processStopwatch.ElapsedMilliseconds > processTimeout.TotalMilliseconds)
+                {
+                    process.Kill();
+
+                    process.WaitForExit((int)5.Seconds().TotalMilliseconds);
+
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Hudl.FFmpeg.Core/Extensions/ProcessExtensions.cs
+++ b/Hudl.FFmpeg.Core/Extensions/ProcessExtensions.cs
@@ -12,7 +12,7 @@ namespace Hudl.FFmpeg.Extensions
         }
         public static bool WaitForProcessStart(this Process process, int? timeoutMilliseconds)
         {
-            var processTimeout = TimeSpan.FromMilliseconds(timeoutMilliseconds ?? 5000);
+            var processTimeout = TimeSpan.FromMilliseconds(timeoutMilliseconds ?? 10000);
             return process.WaitForProcessStart(processTimeout);
         }
         public static bool WaitForProcessStart(this Process process, TimeSpan processTimeout)
@@ -27,7 +27,7 @@ namespace Hudl.FFmpeg.Extensions
 
                 try
                 {
-                    isProcessRunning = (process != null && !process.HasExited && process.Id != 0);
+                    isProcessRunning = (process != null && process.HasExited && process.Id != 0);
                 }
                 catch
                 {

--- a/Hudl.FFmpeg.Core/Extensions/TimeSpanExtensions.cs
+++ b/Hudl.FFmpeg.Core/Extensions/TimeSpanExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hudl.FFmpeg.Extensions
+{
+    public static class TimespanExtensions
+    {
+        public static TimeSpan Milliseconds(this int value)
+        {
+            return TimeSpan.FromMilliseconds(value);
+        }
+
+        public static TimeSpan Milliseconds(this double value)
+        {
+            return TimeSpan.FromMilliseconds(value);
+        }
+
+        public static TimeSpan Seconds(this int value)
+        {
+            return TimeSpan.FromSeconds(value);
+        }
+
+        public static TimeSpan Seconds(this double value)
+        {
+            return TimeSpan.FromSeconds(value);
+        }
+
+        public static TimeSpan Minutes(this int value)
+        {
+            return TimeSpan.FromMinutes(value);
+        }
+
+        public static TimeSpan Minutes(this double value)
+        {
+            return TimeSpan.FromMinutes(value);
+        }
+    }
+}

--- a/Hudl.FFmpeg.Core/Hudl.FFmpeg.Core.csproj
+++ b/Hudl.FFmpeg.Core/Hudl.FFmpeg.Core.csproj
@@ -70,11 +70,11 @@
     <Compile Include="Command\BaseTypes\ICommandBuilder.cs" />
     <Compile Include="Command\CommandConfiguration.cs" />
     <Compile Include="Command\CommandProcessorStatus.cs" />
-    <Compile Include="Command\Models\FFcommandBase.cs" />
+    <Compile Include="Command\Models\FFCommandBase.cs" />
     <Compile Include="Command\BaseTypes\ICommandFactory.cs" />
     <Compile Include="Command\BaseTypes\ICommand.cs" />
     <Compile Include="Command\BaseTypes\ICommandProcessor.cs" />
-    <Compile Include="Command\Models\FFcommandBuilderBase.cs" />
+    <Compile Include="Command\Models\FFCommandBuilderBase.cs" />
     <Compile Include="Command\Models\FFmpegCommandBuilder.cs" />
     <Compile Include="DataTypes\DecimalScale.cs" />
     <Compile Include="DataTypes\DecimalScaleRgb.cs" />

--- a/Hudl.FFmpeg.Core/Hudl.FFmpeg.Core.csproj
+++ b/Hudl.FFmpeg.Core/Hudl.FFmpeg.Core.csproj
@@ -56,8 +56,12 @@
     <Compile Include="Attributes\ValidateAttribute.cs" />
     <Compile Include="Attributes\ForStreamAttribute.cs" />
     <Compile Include="Collections\ForStreamCollection.cs" />
+    <Compile Include="Command\StreamReaders\BaseStandardStreamReader.cs" />
+    <Compile Include="Command\StreamReaders\StandardOutputAsyncStreamReader.cs" />
+    <Compile Include="Command\StreamReaders\StandardErrorAsyncStreamReader.cs" />
     <Compile Include="Enums\FfmpegMergeOptionType.cs" />
     <Compile Include="Enums\SettingsCollectionResourceType.cs" />
+    <Compile Include="Exceptions\FfmpegTimeoutException.cs" />
     <Compile Include="Exceptions\FfmpegProcessingException.cs" />
     <Compile Include="Exceptions\FfmpegRenderingException.cs" />
     <Compile Include="Exceptions\ForStreamInvalidException.cs" />
@@ -80,6 +84,8 @@
     <Compile Include="Enums\LogicalOperators.cs" />
     <Compile Include="Extensions\ArrayExtensions.cs" />
     <Compile Include="Extensions\ObjectExtensions.cs" />
+    <Compile Include="Extensions\ProcessExtensions.cs" />
+    <Compile Include="Extensions\TimeSpanExtensions.cs" />
     <Compile Include="Filters\Attributes\FilterAttribute.cs" />
     <Compile Include="Filters\Attributes\FilterParameterAttribute.cs" />
     <Compile Include="Filters\Contexts\FilterBindingContext.cs" />

--- a/Hudl.FFmpeg.Core/Logging/LogUtility.cs
+++ b/Hudl.FFmpeg.Core/Logging/LogUtility.cs
@@ -60,6 +60,10 @@ namespace Hudl.FFmpeg.Logging
         {
             _log.Error(GetLogMessage(message));
         }
+        public void Error(string message, Exception e)
+        {
+            _log.Error(GetLogMessage(message), e);
+        }
         public void ErrorFormat(string message, params object[] args)
         {
             _log.Error(GetLogMessage(string.Format(message, args)));

--- a/Hudl.FFmpeg.Core/Properties/AssemblyInfo.cs
+++ b/Hudl.FFmpeg.Core/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("3.11.0")]
-[assembly: AssemblyFileVersion("3.11.0")]
+[assembly: AssemblyInformationalVersion("4.0.0")]
+[assembly: AssemblyFileVersion("4.0.0")]
 [assembly: AssemblyVersion("3.0.0.0")]

--- a/Hudl.FFmpeg.Core/Properties/AssemblyInfo.cs
+++ b/Hudl.FFmpeg.Core/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("3.10.0")]
-[assembly: AssemblyFileVersion("3.10.0")]
+[assembly: AssemblyInformationalVersion("3.11.0")]
+[assembly: AssemblyFileVersion("3.11.0")]
 [assembly: AssemblyVersion("3.0.0.0")]

--- a/Hudl.FFmpeg.Core/ResourceManagement.cs
+++ b/Hudl.FFmpeg.Core/ResourceManagement.cs
@@ -1,4 +1,5 @@
 ﻿using Hudl.FFmpeg.Command;
+using System;
 
 namespace Hudl.FFmpeg
 {
@@ -6,5 +7,25 @@ namespace Hudl.FFmpeg
     public class ResourceManagement
     {
         public static CommandConfiguration CommandConfiguration { get; set; }
+
+      
+        private static bool? _isMonoRuntime;
+        /// <summary>
+        /// This usually is considered poor programming style to need to have dependent processing based on runtime, however
+        /// to implement timeout logic and work around existing issues with mono it is necessary. 
+        /// 
+        /// workaround(s)
+        /// 1. workaround for a bug in the mono process when attempting to read async from console output events 
+        ///      - link http://mono.1490590.n4.nabble.com/System-Diagnostic-Process-and-event-handlers-td3246096.html
+        /// </summary>
+        public static bool IsMonoRuntime()
+        {
+            if (!_isMonoRuntime.HasValue)
+            {
+                _isMonoRuntime = (Type.GetType("Mono.Runtime") != null);
+            }
+
+            return _isMonoRuntime ?? false;
+        }
     }
 }

--- a/Hudl.FFmpeg/Command/CommandFactory.cs
+++ b/Hudl.FFmpeg/Command/CommandFactory.cs
@@ -117,6 +117,14 @@ namespace Hudl.FFmpeg.Command
             return RenderWith<FFmpegCommandProcessor, FFmpegCommandBuilder>(timeoutMilliseconds);
         }
 
+        /// <summary>
+        /// Renders the command stream with the defualt command processor
+        /// </summary>
+        public List<IContainer> Render(TimeSpan timeout)
+        {
+            return RenderWith<FFmpegCommandProcessor, FFmpegCommandBuilder>((int)timeout.TotalMilliseconds);
+        }
+
 
         private CommandFactory Add(FFmpegCommand command, bool export)
         {

--- a/Hudl.FFmpeg/Command/CommandFactory.cs
+++ b/Hudl.FFmpeg/Command/CommandFactory.cs
@@ -125,7 +125,6 @@ namespace Hudl.FFmpeg.Command
             return RenderWith<FFmpegCommandProcessor, FFmpegCommandBuilder>((int)timeout.TotalMilliseconds);
         }
 
-
         private CommandFactory Add(FFmpegCommand command, bool export)
         {
             if (command == null)

--- a/Hudl.FFmpeg/Command/CommandFactory.cs
+++ b/Hudl.FFmpeg/Command/CommandFactory.cs
@@ -106,8 +106,17 @@ namespace Hudl.FFmpeg.Command
         /// </summary>
         public List<IContainer> Render()
         {
-            return RenderWith<FFmpegCommandProcessor, FFmpegCommandBuilder>();
+            return RenderWith<FFmpegCommandProcessor, FFmpegCommandBuilder>(null);
         }
+
+        /// <summary>
+        /// Renders the command stream with the defualt command processor
+        /// </summary>
+        public List<IContainer> Render(int timeoutMilliseconds)
+        {
+            return RenderWith<FFmpegCommandProcessor, FFmpegCommandBuilder>(timeoutMilliseconds);
+        }
+
 
         private CommandFactory Add(FFmpegCommand command, bool export)
         {
@@ -133,7 +142,7 @@ namespace Hudl.FFmpeg.Command
 
         #region Internals
 
-        internal List<IContainer> RenderWith<TProcessor, TBuilder>()
+        internal List<IContainer> RenderWith<TProcessor, TBuilder>(int? timeoutMilliseconds)
             where TProcessor : class, ICommandProcessor, new()
             where TBuilder : class, ICommandBuilder, new()
         {
@@ -144,7 +153,7 @@ namespace Hudl.FFmpeg.Command
                 throw new FFmpegRenderingException(commandProcessor.Error);
             }
 
-            var returnType = RenderWith<TProcessor, TBuilder>(commandProcessor);
+            var returnType = RenderWith<TProcessor, TBuilder>(commandProcessor, timeoutMilliseconds);
 
             if (!commandProcessor.Close())
             {
@@ -154,7 +163,7 @@ namespace Hudl.FFmpeg.Command
             return returnType;
         }
 
-        internal List<IContainer> RenderWith<TProcessor, TBuilder>(TProcessor processor)
+        internal List<IContainer> RenderWith<TProcessor, TBuilder>(TProcessor processor, int? timeoutMilliseconds)
             where TProcessor : class, ICommandProcessor, new()
             where TBuilder : class, ICommandBuilder, new()
         {
@@ -171,7 +180,7 @@ namespace Hudl.FFmpeg.Command
 
             CommandList.OfType<FFmpegCommand>()
                 .ToList()
-                .ForEach(command => command.ExecuteWith<TProcessor, TBuilder>(processor)); 
+                .ForEach(command => command.ExecuteWith<TProcessor, TBuilder>(processor, timeoutMilliseconds)); 
 
             return outputList;
         }

--- a/Hudl.FFmpeg/Command/FFmpegCommandBuilder.cs
+++ b/Hudl.FFmpeg/Command/FFmpegCommandBuilder.cs
@@ -15,7 +15,7 @@ using Hudl.FFmpeg.Settings.Utility;
 
 namespace Hudl.FFmpeg.Command
 {
-    internal class FFmpegCommandBuilder: FFcommandBuilderBase, ICommandBuilder
+    internal class FFmpegCommandBuilder: FFCommandBuilderBase, ICommandBuilder
     {
         public void WriteCommand(ICommand command)
         {

--- a/Hudl.FFmpeg/Command/FFmpegCommandProcessor.cs
+++ b/Hudl.FFmpeg/Command/FFmpegCommandProcessor.cs
@@ -78,6 +78,11 @@ namespace Hudl.FFmpeg.Command
             return true;
         }
 
+        public bool Send(string command)
+        {
+            return Send(command, null);
+        }
+
         public bool Send(string command, int? timeoutMilliseconds)
         {
             if (Status != CommandProcessorStatus.Ready)

--- a/Hudl.FFmpeg/Command/FFmpegCommandProcessor.cs
+++ b/Hudl.FFmpeg/Command/FFmpegCommandProcessor.cs
@@ -165,11 +165,7 @@ namespace Hudl.FFmpeg.Command
                 //   - link http://mono.1490590.n4.nabble.com/System-Diagnostic-Process-and-event-handlers-td3246096.html
                 // we will wait a total of 10 seconds for the process to start, if nothing has happened in that time then we will 
                 // return a failure for the event. 
-                var processStarted = ffmpegProcess.WaitForProcessStart();
-                if (!processStarted)
-                {
-                    throw new FFmpegTimeoutException(ffmpegProcess.StartInfo.Arguments);
-                }
+                ffmpegProcess.WaitForProcessStart();
 
                 stdErrorReader.Listen();
 

--- a/Hudl.FFmpeg/Command/FfmpegCommand.cs
+++ b/Hudl.FFmpeg/Command/FfmpegCommand.cs
@@ -48,6 +48,11 @@ namespace Hudl.FFmpeg.Command
             return Render(null);
         }
 
+        public List<CommandOutput> Render(TimeSpan timeout)
+        {
+            return Render((int)timeout.TotalMilliseconds);
+        }
+
         public List<CommandOutput> Render(int? timeoutMilliseconds)
         {
             ExecuteWith<FFmpegCommandProcessor, FFmpegCommandBuilder>(timeoutMilliseconds);

--- a/Hudl.FFmpeg/Command/FfmpegCommand.cs
+++ b/Hudl.FFmpeg/Command/FfmpegCommand.cs
@@ -45,9 +45,14 @@ namespace Hudl.FFmpeg.Command
         /// </summary>
         public List<CommandOutput> Render()
         {
-            ExecuteWith<FFmpegCommandProcessor, FFmpegCommandBuilder>();
+            return Render(null);
+        }
 
-            return Objects.Outputs; 
+        public List<CommandOutput> Render(int? timeoutMilliseconds)
+        {
+            ExecuteWith<FFmpegCommandProcessor, FFmpegCommandBuilder>(timeoutMilliseconds);
+
+            return Objects.Outputs;
         }
 
         #region Internals

--- a/Hudl.FFmpeg/Command/FfmpegCommand.cs
+++ b/Hudl.FFmpeg/Command/FfmpegCommand.cs
@@ -6,7 +6,7 @@ using Hudl.FFmpeg.Filters.BaseTypes;
 
 namespace Hudl.FFmpeg.Command
 {
-    public class FFmpegCommand : FFcommandBase
+    public class FFmpegCommand : FFCommandBase
     {
         private FFmpegCommand(CommandFactory owner)
         {

--- a/Hudl.FFmpeg/Hudl.Ffmpeg.csproj
+++ b/Hudl.FFmpeg/Hudl.Ffmpeg.csproj
@@ -71,7 +71,7 @@
     <Compile Include="Metadata\Interfaces\IMetadataManipulation.cs" />
     <Compile Include="Metadata\MetadataHelpers.cs" />
     <Compile Include="Metadata\MetadataInfoStreamCalculator.cs" />
-    <Compile Include="Command\FFmpegProcessorReciever.cs" />
+    <Compile Include="Command\FFmpegCommandProcessor.cs" />
     <Compile Include="Command\FFmpegCommandBuilder.cs" />
     <Compile Include="Command\CommandFactory.cs" />
     <Compile Include="Command\CommandObjects.cs" />

--- a/Hudl.FFmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.FFmpeg/Properties/AssemblyInfo.cs
@@ -36,6 +36,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyInformationalVersion("3.10.0")]
-[assembly: AssemblyFileVersion("3.10.0")]
+[assembly: AssemblyInformationalVersion("3.11.0")]
+[assembly: AssemblyFileVersion("3.11.0")]
 [assembly: AssemblyVersion("3.0.0.0")]

--- a/Hudl.FFmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.FFmpeg/Properties/AssemblyInfo.cs
@@ -36,6 +36,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyInformationalVersion("3.11.0")]
-[assembly: AssemblyFileVersion("3.11.0")]
+[assembly: AssemblyInformationalVersion("4.0.0")]
+[assembly: AssemblyFileVersion("4.0.0")]
 [assembly: AssemblyVersion("3.0.0.0")]

--- a/Hudl.FFprobe/Command/FFprobeCommand.cs
+++ b/Hudl.FFprobe/Command/FFprobeCommand.cs
@@ -36,6 +36,11 @@ namespace Hudl.FFprobe.Command
             return this;
         }
 
+        public ICommandProcessor Execute()
+        {
+            return Execute(null);
+        }
+
         public ICommandProcessor Execute(int? timeoutMilliseconds)
         {
             return ExecuteWith<FFprobeCommandProcessor, FFprobeCommandBuilder>(timeoutMilliseconds);

--- a/Hudl.FFprobe/Command/FFprobeCommand.cs
+++ b/Hudl.FFprobe/Command/FFprobeCommand.cs
@@ -36,9 +36,10 @@ namespace Hudl.FFprobe.Command
             return this;
         }
 
-        public ICommandProcessor Execute()
+        public ICommandProcessor Execute(int? timeoutMilliseconds)
         {
-            return ExecuteWith<FFprobeCommandProcessor, FFprobeCommandBuilder>();
+            return ExecuteWith<FFprobeCommandProcessor, FFprobeCommandBuilder>(timeoutMilliseconds);
         }
+
     }
 }

--- a/Hudl.FFprobe/Command/FFprobeCommand.cs
+++ b/Hudl.FFprobe/Command/FFprobeCommand.cs
@@ -7,7 +7,7 @@ using Hudl.FFmpeg.Settings.Interfaces;
 
 namespace Hudl.FFprobe.Command
 {
-    public class FFprobeCommand : FFcommandBase
+    public class FFprobeCommand : FFCommandBase
     {
         private FFprobeCommand(IContainer resource)
         {

--- a/Hudl.FFprobe/Command/FFprobeCommandBuilder.cs
+++ b/Hudl.FFprobe/Command/FFprobeCommandBuilder.cs
@@ -6,7 +6,7 @@ using Hudl.FFmpeg.Settings.Serialization;
 
 namespace Hudl.FFprobe.Command
 {
-    internal class FFprobeCommandBuilder : FFcommandBuilderBase, ICommandBuilder
+    internal class FFprobeCommandBuilder : FFCommandBuilderBase, ICommandBuilder
     {
         public void WriteCommand(ICommand command)
         {

--- a/Hudl.FFprobe/Command/FFprobeCommandProcessor.cs
+++ b/Hudl.FFprobe/Command/FFprobeCommandProcessor.cs
@@ -75,6 +75,11 @@ namespace Hudl.FFprobe.Command
             return true;
         }
 
+        public bool Send(string command)
+        {
+            return Send(command, null);
+        }
+
         public bool Send(string command, int? timeoutMilliseconds)
         {
             if (Status != CommandProcessorStatus.Ready)

--- a/Hudl.FFprobe/Command/FFprobeCommandProcessor.cs
+++ b/Hudl.FFprobe/Command/FFprobeCommandProcessor.cs
@@ -6,7 +6,6 @@ using Hudl.FFmpeg.Command;
 using Hudl.FFmpeg.Command.BaseTypes;
 using Hudl.FFmpeg.Exceptions;
 using Hudl.FFmpeg.Logging;
-using System.ComponentModel;
 
 namespace Hudl.FFprobe.Command
 {
@@ -91,7 +90,7 @@ namespace Hudl.FFprobe.Command
             {
                 Status = CommandProcessorStatus.Processing;
 
-                ProcessIt(command);
+                ProcessIt(command, timeoutMilliseconds);
 
                 Status = CommandProcessorStatus.Ready;
             }
@@ -145,31 +144,9 @@ namespace Hudl.FFprobe.Command
                 
                 FFprobeProcess.Start();
                 
-                if (timeoutMilliseconds.HasValue)
-                {
-                    StdOut = FFprobeProcess.StandardOutput.reed;
+                StdOut = FFprobeProcess.StandardOutput.ReadToEnd();
 
-                    FFprobeProcess.WaitForExit();
-                }
-                else
-                {
-                    var hasExited = FFprobeProcess.WaitForExit(timeoutMilliseconds.Value);
-                    if (!hasExited)
-                    {
-                        try
-                        {
-                            FFprobeProcess.Kill();
-
-                            FFprobeProcess.WaitForExit();
-                        }
-                        catch(Win32Exception ex)
-                        {
-                            Log.DebugFormat("FFprobe.exe access denied, already exited"); 
-                        }
-
-                        throw new FFmpegTimeoutException(command.Trim()); 
-                    }
-                }
+                FFprobeProcess.WaitForExit();
 
                 Log.DebugFormat("FFprobe.exe Output={0}.", StdOut);
 

--- a/Hudl.FFprobe/MediaLoader.cs
+++ b/Hudl.FFprobe/MediaLoader.cs
@@ -40,7 +40,7 @@ namespace Hudl.FFprobe
                 ffprobeCommand.AddSetting(new ShowFrames());
             }
                                                
-            var commandProcessor = ffprobeCommand.Execute();
+            var commandProcessor = ffprobeCommand.Execute(null);
 
             var containerMetadata = FFprobeSerializer.Serialize(commandProcessor);
 

--- a/Hudl.FFprobe/Properties/AssemblyInfo.cs
+++ b/Hudl.FFprobe/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("3.11.0")]
-[assembly: AssemblyFileVersion("3.11.0")]
+[assembly: AssemblyInformationalVersion("4.0.0")]
+[assembly: AssemblyFileVersion("4.0.0")]
 [assembly: AssemblyVersion("3.0.0.0")]

--- a/Hudl.FFprobe/Properties/AssemblyInfo.cs
+++ b/Hudl.FFprobe/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("3.10.0")]
-[assembly: AssemblyFileVersion("3.10.0")]
+[assembly: AssemblyInformationalVersion("3.11.0")]
+[assembly: AssemblyFileVersion("3.11.0")]
 [assembly: AssemblyVersion("3.0.0.0")]

--- a/Hudl.Ffmpeg.Tests/Command/CommandFactoryTests.cs
+++ b/Hudl.Ffmpeg.Tests/Command/CommandFactoryTests.cs
@@ -58,7 +58,7 @@ namespace Hudl.FFmpeg.Tests.Command
                    .WithInput<VideoStream>(Utilities.GetVideoFile())
                    .To<Mp4>();
 
-            var result = factory.RenderWith<TestCommandProcessor, FFmpegCommandBuilder>();
+            var result = factory.RenderWith<TestCommandProcessor, FFmpegCommandBuilder>(null);
 
             Assert.True(result.Count == 1);
         }

--- a/Hudl.Ffmpeg.Tests/Command/CommandTests.cs
+++ b/Hudl.Ffmpeg.Tests/Command/CommandTests.cs
@@ -197,7 +197,7 @@ namespace Hudl.FFmpeg.Tests.Command
 
             command.AddInput(Assets.Utilities.GetVideoFile());
 
-            Assert.DoesNotThrow(() => command.ExecuteWith<TestCommandProcessor, FFmpegCommandBuilder>());
+            Assert.DoesNotThrow(() => command.ExecuteWith<TestCommandProcessor, FFmpegCommandBuilder>(null));
         }
 
         [Fact]
@@ -213,7 +213,7 @@ namespace Hudl.FFmpeg.Tests.Command
                                        beforeRenderExecuted = true;
                                    });
 
-            stage.Command.ExecuteWith<TestCommandProcessor, FFmpegCommandBuilder>(); 
+            stage.Command.ExecuteWith<TestCommandProcessor, FFmpegCommandBuilder>(null); 
 
             Assert.True(beforeRenderExecuted);
         }
@@ -231,7 +231,7 @@ namespace Hudl.FFmpeg.Tests.Command
                                        afterRenderExecuted = true;
                                    });
 
-            stage.Command.ExecuteWith<TestCommandProcessor, FFmpegCommandBuilder>();
+            stage.Command.ExecuteWith<TestCommandProcessor, FFmpegCommandBuilder>(null);
 
             Assert.True(afterRenderExecuted);
         }

--- a/Hudl.Ffmpeg.Tests/Command/TestCommandProcessor.cs
+++ b/Hudl.Ffmpeg.Tests/Command/TestCommandProcessor.cs
@@ -28,7 +28,7 @@ namespace Hudl.FFmpeg.Tests.Command
             return true;
         }
 
-        public bool Send(string command)
+        public bool Send(string command, int? timeout)
         {
             SendFired = true;
             return true;

--- a/Hudl.Ffmpeg.Tests/Command/TestCommandProcessor.cs
+++ b/Hudl.Ffmpeg.Tests/Command/TestCommandProcessor.cs
@@ -28,6 +28,11 @@ namespace Hudl.FFmpeg.Tests.Command
             return true;
         }
 
+        public bool Send(string command)
+        {
+            return Send(command, null);
+        }
+
         public bool Send(string command, int? timeout)
         {
             SendFired = true;


### PR DESCRIPTION
Implement a Mono and Windows based async process monitor. 

This process monitor will let us add timeouts and standard error and out `stderr` and `stdout` monitoring. This opens the route for things like progress monitoring, and special event detection. 