### PR TITLE
ICommandProcessor changes, and new filters and defaults

### DIFF
--- a/Hudl.FFmpeg.Core/Command/BaseTypes/ICommandProcessor.cs
+++ b/Hudl.FFmpeg.Core/Command/BaseTypes/ICommandProcessor.cs
@@ -21,7 +21,12 @@ namespace Hudl.FFmpeg.Command.BaseTypes
         /// contains the stdout message from the last command.
         /// </summary>
         string StdOut { get; }
-        
+
+        /// <summary>
+        /// contains the last ran Arguments through the processor
+        /// </summary>
+        string Arguments { get; }
+
         /// <summary>
         /// opens a command builder session, should get the processor started and ready to recieve commands
         /// </summary>

--- a/Hudl.FFmpeg.Core/Command/BaseTypes/ICommandProcessor.cs
+++ b/Hudl.FFmpeg.Core/Command/BaseTypes/ICommandProcessor.cs
@@ -25,7 +25,7 @@ namespace Hudl.FFmpeg.Command.BaseTypes
         /// <summary>
         /// contains the last ran Arguments through the processor
         /// </summary>
-        string Arguments { get; }
+        string Command { get; }
 
         /// <summary>
         /// opens a command builder session, should get the processor started and ready to recieve commands

--- a/Hudl.FFmpeg.Core/Properties/AssemblyInfo.cs
+++ b/Hudl.FFmpeg.Core/Properties/AssemblyInfo.cs
@@ -34,4 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyInformationalVersion("5.0.0")]
 [assembly: AssemblyFileVersion("5.0.0")]
-[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyVersion("5.0.0.0")]

--- a/Hudl.FFmpeg.Core/Properties/AssemblyInfo.cs
+++ b/Hudl.FFmpeg.Core/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("4.0.0")]
-[assembly: AssemblyFileVersion("4.0.0")]
+[assembly: AssemblyInformationalVersion("5.0.0")]
+[assembly: AssemblyFileVersion("5.0.0")]
 [assembly: AssemblyVersion("3.0.0.0")]

--- a/Hudl.FFmpeg/Command/FFmpegCommandProcessor.cs
+++ b/Hudl.FFmpeg/Command/FFmpegCommandProcessor.cs
@@ -24,7 +24,7 @@ namespace Hudl.FFmpeg.Command
         public Exception Error { get; protected set; }
 
         public string StdOut { get; protected set; }
-        public string Arguments { get; protected set; }
+        public string Command { get; protected set; }
 
         public CommandProcessorStatus Status { get; protected set; }
 
@@ -95,7 +95,7 @@ namespace Hudl.FFmpeg.Command
                 throw new ArgumentException("Processing command cannot be null or empty.", "command");
             }
 
-            Arguments = command; 
+            Command = command; 
 
             var retryCount = 0; 
             var isSuccessful = false;

--- a/Hudl.FFmpeg/Command/FFmpegCommandProcessor.cs
+++ b/Hudl.FFmpeg/Command/FFmpegCommandProcessor.cs
@@ -24,6 +24,7 @@ namespace Hudl.FFmpeg.Command
         public Exception Error { get; protected set; }
 
         public string StdOut { get; protected set; }
+        public string Arguments { get; protected set; }
 
         public CommandProcessorStatus Status { get; protected set; }
 
@@ -93,6 +94,8 @@ namespace Hudl.FFmpeg.Command
             {
                 throw new ArgumentException("Processing command cannot be null or empty.", "command");
             }
+
+            Arguments = command; 
 
             var retryCount = 0; 
             var isSuccessful = false;

--- a/Hudl.FFmpeg/Filters/Overlay.cs
+++ b/Hudl.FFmpeg/Filters/Overlay.cs
@@ -25,6 +25,7 @@ namespace Hudl.FFmpeg.Filters
         {
             Format = OverlayVideoFormatType.Yuv420; 
             Eval = OverlayVideoEvalType.Frame;
+            RepeatLast = true;
         }
         public Overlay(int x, int y)
             : this()
@@ -42,7 +43,7 @@ namespace Hudl.FFmpeg.Filters
         [FilterParameter(Name = "shortest", Default = false, Formatter = typeof(BoolToInt32Formatter))]
         public bool Shortest { get; set; }
 
-        [FilterParameter(Name = "repeatlast", Default = false, Formatter = typeof(BoolToInt32Formatter))]
+        [FilterParameter(Name = "repeatlast", Default = true, Formatter = typeof(BoolToInt32Formatter))]
         public bool RepeatLast { get; set; }
        
         [FilterParameter(Name ="eval", Default = OverlayVideoEvalType.Frame, Formatter = typeof(EnumParameterFormatter))]

--- a/Hudl.FFmpeg/Hudl.Ffmpeg.csproj
+++ b/Hudl.FFmpeg/Hudl.Ffmpeg.csproj
@@ -123,6 +123,9 @@
     <Compile Include="Settings\ChannelInput.cs" />
     <Compile Include="Settings\DurationOutput.cs" />
     <Compile Include="Settings\FrameDropThreshold.cs" />
+    <Compile Include="Settings\MapChapters.cs" />
+    <Compile Include="Settings\MapMetadata.cs" />
+    <Compile Include="Settings\LogLevel.cs" />
     <Compile Include="Settings\LoopInput.cs" />
     <Compile Include="Settings\CopyTimestamps.cs" />
     <Compile Include="Settings\QualityScaleAudio.cs" />

--- a/Hudl.FFmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.FFmpeg/Properties/AssemblyInfo.cs
@@ -36,6 +36,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyInformationalVersion("4.0.0")]
-[assembly: AssemblyFileVersion("4.0.0")]
+[assembly: AssemblyInformationalVersion("5.0.0")]
+[assembly: AssemblyFileVersion("5.0.0")]
 [assembly: AssemblyVersion("3.0.0.0")]

--- a/Hudl.FFmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.FFmpeg/Properties/AssemblyInfo.cs
@@ -38,4 +38,4 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyInformationalVersion("5.0.0")]
 [assembly: AssemblyFileVersion("5.0.0")]
-[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyVersion("5.0.0.0")]

--- a/Hudl.FFmpeg/Settings/LogLevel.cs
+++ b/Hudl.FFmpeg/Settings/LogLevel.cs
@@ -1,0 +1,24 @@
+﻿using Hudl.FFmpeg.Attributes;
+using Hudl.FFmpeg.Resources.BaseTypes;
+using Hudl.FFmpeg.Settings.Attributes;
+using Hudl.FFmpeg.Settings.Interfaces;
+
+namespace Hudl.FFmpeg.Settings
+{
+    /// <summary>
+    /// set the logging level used by the target library.
+    /// </summary>
+    [ForStream(Type = typeof(AudioStream))]
+    [ForStream(Type = typeof(VideoStream))]
+    [Setting(Name = "loglevel")]
+    public class LogLevel : ISetting
+    {
+        public LogLevel(string level)
+        {
+            Level = level;
+        }
+
+        [SettingParameter]
+        public string Level { get; set; }
+    }
+}

--- a/Hudl.FFmpeg/Settings/MapChapters.cs
+++ b/Hudl.FFmpeg/Settings/MapChapters.cs
@@ -1,0 +1,24 @@
+﻿using Hudl.FFmpeg.Attributes;
+using Hudl.FFmpeg.Resources.BaseTypes;
+using Hudl.FFmpeg.Settings.Attributes;
+using Hudl.FFmpeg.Settings.Interfaces;
+
+namespace Hudl.FFmpeg.Settings
+{
+    /// <summary>
+    /// copy chapters from input file with index input_file_index to the next output file..
+    /// </summary>
+    [ForStream(Type = typeof(AudioStream))]
+    [ForStream(Type = typeof(VideoStream))]
+    [Setting(Name = "map_chapters")]
+    public class MapChapters : ISetting
+    {
+        public MapChapters(string mapping)
+        {
+            Mapping = mapping;
+        }
+
+        [SettingParameter]
+        public string Mapping { get; set; }
+    }
+}

--- a/Hudl.FFmpeg/Settings/MapMetadata.cs
+++ b/Hudl.FFmpeg/Settings/MapMetadata.cs
@@ -1,0 +1,24 @@
+﻿using Hudl.FFmpeg.Attributes;
+using Hudl.FFmpeg.Resources.BaseTypes;
+using Hudl.FFmpeg.Settings.Attributes;
+using Hudl.FFmpeg.Settings.Interfaces;
+
+namespace Hudl.FFmpeg.Settings
+{
+    /// <summary>
+    /// set metadata information of the next output file from infile.
+    /// </summary>
+    [ForStream(Type = typeof(AudioStream))]
+    [ForStream(Type = typeof(VideoStream))]
+    [Setting(Name = "map_metadata")]
+    public class MapMetadata : ISetting
+    {
+        public MapMetadata(string mapping)
+        {
+            Mapping = mapping;
+        }
+
+        [SettingParameter]
+        public string Mapping { get; set; }
+    }
+}

--- a/Hudl.FFprobe/Command/FFprobeCommandProcessor.cs
+++ b/Hudl.FFprobe/Command/FFprobeCommandProcessor.cs
@@ -21,7 +21,7 @@ namespace Hudl.FFprobe.Command
         public Exception Error { get; protected set; }
 
         public string StdOut { get; protected set; }
-        public string Arguments { get; protected set; }
+        public string Command { get; protected set; }
 
         public CommandProcessorStatus Status { get; protected set; }
 
@@ -92,7 +92,7 @@ namespace Hudl.FFprobe.Command
                 throw new ArgumentException("Processing command cannot be null or empty.", "command");
             }
 
-            Arguments = command; 
+            Command = command; 
 
             try
             {

--- a/Hudl.FFprobe/Command/FFprobeCommandProcessor.cs
+++ b/Hudl.FFprobe/Command/FFprobeCommandProcessor.cs
@@ -21,6 +21,7 @@ namespace Hudl.FFprobe.Command
         public Exception Error { get; protected set; }
 
         public string StdOut { get; protected set; }
+        public string Arguments { get; protected set; }
 
         public CommandProcessorStatus Status { get; protected set; }
 
@@ -90,6 +91,8 @@ namespace Hudl.FFprobe.Command
             {
                 throw new ArgumentException("Processing command cannot be null or empty.", "command");
             }
+
+            Arguments = command; 
 
             try
             {

--- a/Hudl.FFprobe/Properties/AssemblyInfo.cs
+++ b/Hudl.FFprobe/Properties/AssemblyInfo.cs
@@ -34,4 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyInformationalVersion("5.0.0")]
 [assembly: AssemblyFileVersion("5.0.0")]
-[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyVersion("5.0.0.0")]

--- a/Hudl.FFprobe/Properties/AssemblyInfo.cs
+++ b/Hudl.FFprobe/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("4.0.0")]
-[assembly: AssemblyFileVersion("4.0.0")]
+[assembly: AssemblyInformationalVersion("5.0.0")]
+[assembly: AssemblyFileVersion("5.0.0")]
 [assembly: AssemblyVersion("3.0.0.0")]

--- a/Hudl.Ffmpeg.Tests/Command/TestCommandProcessor.cs
+++ b/Hudl.Ffmpeg.Tests/Command/TestCommandProcessor.cs
@@ -14,6 +14,8 @@ namespace Hudl.FFmpeg.Tests.Command
 
         public string StdOut { get; protected set; }
 
+        public string Arguments { get; protected set; }
+
         public Exception Error { get; protected set; }
 
         public bool Open()
@@ -35,6 +37,7 @@ namespace Hudl.FFmpeg.Tests.Command
 
         public bool Send(string command, int? timeout)
         {
+            Arguments = command;
             SendFired = true;
             return true;
         }

--- a/Hudl.Ffmpeg.Tests/Command/TestCommandProcessor.cs
+++ b/Hudl.Ffmpeg.Tests/Command/TestCommandProcessor.cs
@@ -14,7 +14,7 @@ namespace Hudl.FFmpeg.Tests.Command
 
         public string StdOut { get; protected set; }
 
-        public string Arguments { get; protected set; }
+        public string Command { get; protected set; }
 
         public Exception Error { get; protected set; }
 
@@ -37,7 +37,7 @@ namespace Hudl.FFmpeg.Tests.Command
 
         public bool Send(string command, int? timeout)
         {
-            Arguments = command;
+            Command = command;
             SendFired = true;
             return true;
         }


### PR DESCRIPTION
## Description 
The `ICommandProcessor` interface was changed to add the command string to allow visibility to those about the command that was run. This is easily accessble through the `OnSuccess`, and `OnError` handlers of the `FFmpegCommand` object.

`MapMetadata` `MapChapters` and `LogLevel` settings were all added. 

the `Overlay` filter default of `repeatlast` was changed to reflect ffmpeg documentation that `true` is the default argument. 