### PR TITLE
Switch SeekPositionInput to be PreDeclaration

### DIFF
--- a/Hudl.FFmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.FFmpeg/Properties/AssemblyInfo.cs
@@ -36,6 +36,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyInformationalVersion("6.0.0")]
-[assembly: AssemblyFileVersion("6.0.0")]
+[assembly: AssemblyInformationalVersion("6.1.0")]
+[assembly: AssemblyFileVersion("6.1.0")]
 [assembly: AssemblyVersion("6.0.0.0")]

--- a/Hudl.FFmpeg/Settings/SeekPositionInput.cs
+++ b/Hudl.FFmpeg/Settings/SeekPositionInput.cs
@@ -12,7 +12,7 @@ namespace Hudl.FFmpeg.Settings
     /// </summary>
     [ForStream(Type = typeof(AudioStream))]
     [ForStream(Type = typeof(VideoStream))]
-    [Setting(Name = "ss", IsPreDeclaration = false, ResourceType = SettingsCollectionResourceType.Input)]
+    [Setting(Name = "ss", IsPreDeclaration = true, ResourceType = SettingsCollectionResourceType.Input)]
     public class SeekPositionInput : BaseSeekPosition
     {
         public SeekPositionInput(TimeSpan length)


### PR DESCRIPTION
This change will allow us to specify the -ss param before the input, which should allow for more accurate seeking. I think the current behavior, with -ss after the output, is the same as SeekPositionOutput.