### PR TITLE
Add bitmap container type support

### DIFF
--- a/Hudl.FFmpeg.Core/Properties/AssemblyInfo.cs
+++ b/Hudl.FFmpeg.Core/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("6.0.0")]
-[assembly: AssemblyFileVersion("6.0.0")]
+[assembly: AssemblyInformationalVersion("6.2.0")]
+[assembly: AssemblyFileVersion("6.2.0")]
 [assembly: AssemblyVersion("6.0.0.0")]

--- a/Hudl.FFmpeg/Hudl.Ffmpeg.csproj
+++ b/Hudl.FFmpeg/Hudl.Ffmpeg.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Resources\BaseTypes\VideoStream.cs" />
     <Compile Include="Resources\Ismv.cs" />
     <Compile Include="Resources\Avi.cs" />
+    <Compile Include="Resources\Bmp.cs" />
     <Compile Include="Resources\Nut.cs" />
     <Compile Include="Resources\Ogg.cs" />
     <Compile Include="Resources\Mkv.cs" />

--- a/Hudl.FFmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.FFmpeg/Properties/AssemblyInfo.cs
@@ -36,6 +36,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyInformationalVersion("6.1.0")]
-[assembly: AssemblyFileVersion("6.1.0")]
+[assembly: AssemblyInformationalVersion("6.2.0")]
+[assembly: AssemblyFileVersion("6.2.0")]
 [assembly: AssemblyVersion("6.0.0.0")]

--- a/Hudl.FFmpeg/Resources/Bmp.cs
+++ b/Hudl.FFmpeg/Resources/Bmp.cs
@@ -1,0 +1,23 @@
+﻿using Hudl.FFmpeg.Attributes;
+using Hudl.FFmpeg.Resources.BaseTypes;
+using Hudl.FFmpeg.Resources.Interfaces;
+
+namespace Hudl.FFmpeg.Resources
+{
+    [ContainsStream(Type = typeof(VideoStream))]
+    [ContainsStream(Type = typeof(DataStream))]
+    public class Bmp : BaseContainer
+    {
+        private const string FileFormat = ".Bmp";
+
+        public Bmp() 
+            : base(FileFormat)
+        {
+        }
+
+        protected override IContainer Clone()
+        {
+            return new Bmp();
+        }
+    }
+}

--- a/Hudl.FFprobe/Properties/AssemblyInfo.cs
+++ b/Hudl.FFprobe/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("6.0.0")]
-[assembly: AssemblyFileVersion("6.0.0")]
+[assembly: AssemblyInformationalVersion("6.2.0")]
+[assembly: AssemblyFileVersion("6.2.0")]
 [assembly: AssemblyVersion("6.0.0.0")]


### PR DESCRIPTION
Adds ability to load streams and information from a BMP container. This container will be shipped with the ability to parse `DataStream`s and `VideoStream`s

