### PR TITLE
Make frame rate available as an input option and output option

### DIFF
--- a/Hudl.FFmpeg.Core/Properties/AssemblyInfo.cs
+++ b/Hudl.FFmpeg.Core/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("6.2.0")]
-[assembly: AssemblyFileVersion("6.2.0")]
+[assembly: AssemblyInformationalVersion("6.3.0")]
+[assembly: AssemblyFileVersion("6.3.0")]
 [assembly: AssemblyVersion("6.0.0.0")]

--- a/Hudl.FFmpeg/Hudl.Ffmpeg.csproj
+++ b/Hudl.FFmpeg/Hudl.Ffmpeg.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Resources\Txt.cs" />
     <Compile Include="Settings\AutoConvert.cs" />
     <Compile Include="Settings\BaseTypes\BaseBitStreamFilter.cs" />
+    <Compile Include="Settings\BaseTypes\BaseFrameRate.cs" />
     <Compile Include="Settings\BaseTypes\BaseSeekPosition.cs" />
     <Compile Include="Settings\BaseTypes\BaseDuration.cs" />
     <Compile Include="Settings\BaseTypes\BaseChannel.cs" />
@@ -126,6 +127,7 @@
     <Compile Include="Settings\ChannelInput.cs" />
     <Compile Include="Settings\DurationOutput.cs" />
     <Compile Include="Settings\FrameDropThreshold.cs" />
+    <Compile Include="Settings\FrameRateInput.cs" />
     <Compile Include="Settings\MapChapters.cs" />
     <Compile Include="Settings\MapMetadata.cs" />
     <Compile Include="Settings\LogLevel.cs" />

--- a/Hudl.FFmpeg/Properties/AssemblyInfo.cs
+++ b/Hudl.FFmpeg/Properties/AssemblyInfo.cs
@@ -36,6 +36,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyInformationalVersion("6.2.0")]
-[assembly: AssemblyFileVersion("6.2.0")]
+[assembly: AssemblyInformationalVersion("6.3.0")]
+[assembly: AssemblyFileVersion("6.3.0")]
 [assembly: AssemblyVersion("6.0.0.0")]

--- a/Hudl.FFmpeg/Settings/BaseTypes/BaseFrameRate.cs
+++ b/Hudl.FFmpeg/Settings/BaseTypes/BaseFrameRate.cs
@@ -1,0 +1,30 @@
+﻿using Hudl.FFmpeg.Attributes;
+using Hudl.FFmpeg.Enums;
+using Hudl.FFmpeg.Formatters.Utility;
+using Hudl.FFmpeg.Settings.Attributes;
+using Hudl.FFmpeg.Settings.Interfaces;
+using Hudl.FFmpeg.Validators;
+using System;
+
+namespace Hudl.FFmpeg.Settings.BaseTypes
+{
+    public abstract class BaseFrameRate : ISetting
+    {
+        public BaseFrameRate()
+        {
+        }
+        public BaseFrameRate(double rate)
+        {
+            if (rate <= 0)
+            {
+                throw new ArgumentException("Frame rate must be greater than zero.");
+            }
+
+            Rate = rate;
+        }
+
+        [SettingParameter]
+        [Validate(LogicalOperators.GreaterThan, 0)]
+        public double Rate { get; set; }
+    }
+}

--- a/Hudl.FFmpeg/Settings/FrameRate.cs
+++ b/Hudl.FFmpeg/Settings/FrameRate.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using Hudl.FFmpeg.Attributes;
-using Hudl.FFmpeg.Enums;
+﻿using Hudl.FFmpeg.Attributes;
 using Hudl.FFmpeg.Resources.BaseTypes;
 using Hudl.FFmpeg.Settings.Attributes;
-using Hudl.FFmpeg.Settings.Interfaces;
+using Hudl.FFmpeg.Settings.BaseTypes;
 
 namespace Hudl.FFmpeg.Settings
 {
@@ -12,23 +10,15 @@ namespace Hudl.FFmpeg.Settings
     /// </summary>
     [ForStream(Type = typeof(VideoStream))]
     [Setting(Name = "r")]
-    public class FrameRate : ISetting
+    public class FrameRate : BaseFrameRate
     {
         public FrameRate()
+            : base()
         {
         }
         public FrameRate(double rate)
+            : base(rate)
         {
-            if (rate <= 0)
-            {
-                throw new ArgumentException("Frame rate must be greater than zero.");
-            }
-
-            Rate = rate;
         }
-
-        [SettingParameter]
-        [Validate(LogicalOperators.GreaterThan, 0)]
-        public double Rate { get; set; }
     }
 }

--- a/Hudl.FFmpeg/Settings/FrameRateInput.cs
+++ b/Hudl.FFmpeg/Settings/FrameRateInput.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Hudl.FFmpeg.Attributes;
+using Hudl.FFmpeg.Enums;
+using Hudl.FFmpeg.Resources.BaseTypes;
+using Hudl.FFmpeg.Settings.Attributes;
+using Hudl.FFmpeg.Settings.BaseTypes;
+
+namespace Hudl.FFmpeg.Settings
+{
+    /// <summary>
+    /// Set frame rate (Hz value, fraction or abbreviation).
+    /// </summary>
+    [ForStream(Type = typeof(VideoStream))]
+    [Setting(Name = "r", ResourceType = SettingsCollectionResourceType.Input)]
+    public class FrameRateInput : BaseFrameRate
+    {
+        public FrameRateInput()
+        {
+        }
+        public FrameRateInput(double rate)
+        {
+            if (rate <= 0)
+            {
+                throw new ArgumentException("Frame rate must be greater than zero.");
+            }
+
+            Rate = rate;
+        }
+
+        [SettingParameter]
+        [Validate(LogicalOperators.GreaterThan, 0)]
+        public double Rate { get; set; }
+    }
+}

--- a/Hudl.FFmpeg/Settings/FrameRateInput.cs
+++ b/Hudl.FFmpeg/Settings/FrameRateInput.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Hudl.FFmpeg.Attributes;
+﻿using Hudl.FFmpeg.Attributes;
 using Hudl.FFmpeg.Enums;
 using Hudl.FFmpeg.Resources.BaseTypes;
 using Hudl.FFmpeg.Settings.Attributes;
@@ -15,20 +14,12 @@ namespace Hudl.FFmpeg.Settings
     public class FrameRateInput : BaseFrameRate
     {
         public FrameRateInput()
+            : base()
         {
         }
         public FrameRateInput(double rate)
+            : base(rate)
         {
-            if (rate <= 0)
-            {
-                throw new ArgumentException("Frame rate must be greater than zero.");
-            }
-
-            Rate = rate;
         }
-
-        [SettingParameter]
-        [Validate(LogicalOperators.GreaterThan, 0)]
-        public double Rate { get; set; }
     }
 }

--- a/Hudl.FFprobe/Properties/AssemblyInfo.cs
+++ b/Hudl.FFprobe/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("6.2.0")]
-[assembly: AssemblyFileVersion("6.2.0")]
+[assembly: AssemblyInformationalVersion("6.3.0")]
+[assembly: AssemblyFileVersion("6.3.0")]
 [assembly: AssemblyVersion("6.0.0.0")]


### PR DESCRIPTION
Creates an output option and input option for the frame rate setting. This will allow users to force the decoder into reading GLOB patterns of images or other input types at a frame rate of their choosing.