### PR TITLE
Support subtitles in Hudl.FFprobe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ goo-tests
 config.codekit
 
 /WebApp/Css/Sass/config.codekit
+/.vs

--- a/Hudl.FFmpeg/Hudl.Ffmpeg.csproj
+++ b/Hudl.FFmpeg/Hudl.Ffmpeg.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Metadata\Models\MetadataInfoTreeSource.cs" />
     <Compile Include="Resources\BaseTypes\DataStream.cs" />
     <Compile Include="Resources\BaseTypes\AudioStream.cs" />
+    <Compile Include="Resources\BaseTypes\SubtitleStream.cs" />
     <Compile Include="Resources\BaseTypes\VideoStream.cs" />
     <Compile Include="Resources\Ismv.cs" />
     <Compile Include="Resources\Avi.cs" />

--- a/Hudl.FFmpeg/Hudl.Ffmpeg.csproj
+++ b/Hudl.FFmpeg/Hudl.Ffmpeg.csproj
@@ -104,6 +104,8 @@
     <Compile Include="Resources\BaseTypes\AudioStream.cs" />
     <Compile Include="Resources\BaseTypes\SubtitleStream.cs" />
     <Compile Include="Resources\BaseTypes\VideoStream.cs" />
+    <Compile Include="Resources\Ass.cs" />
+    <Compile Include="Resources\Srt.cs" />
     <Compile Include="Resources\Ismv.cs" />
     <Compile Include="Resources\Avi.cs" />
     <Compile Include="Resources\Bmp.cs" />

--- a/Hudl.FFmpeg/Metadata/Models/MetadataInfo.cs
+++ b/Hudl.FFmpeg/Metadata/Models/MetadataInfo.cs
@@ -12,11 +12,15 @@ namespace Hudl.FFmpeg.Metadata.Models
 
         public bool HasVideo { get { return VideoMetadata != null; } }
 
+        public bool HasSubtitle { get { return SubtitleMetadata != null; } }
+
         public bool HasData { get { return DataMetadata != null; } }
 
         public AudioStreamMetadata AudioMetadata { get; internal set; }
 
         public VideoStreamMetadata VideoMetadata { get; internal set; }
+
+        public SubtitleStreamMetadata SubtitleMetadata { get; internal set; }
 
         public DataStreamMetadata DataMetadata { get; internal set; }
 
@@ -27,6 +31,7 @@ namespace Hudl.FFmpeg.Metadata.Models
                 AudioMetadata = HasAudio ? AudioMetadata.Copy() : null,
                 VideoMetadata = HasVideo ? VideoMetadata.Copy() : null,
                 DataMetadata = HasData ? DataMetadata.Copy() : null,
+                SubtitleMetadata = HasSubtitle ? SubtitleMetadata.Copy() : null,
             };
         }
 
@@ -48,6 +53,14 @@ namespace Hudl.FFmpeg.Metadata.Models
             return new MetadataInfo
             {
                 VideoMetadata = loader,
+            };
+        }
+
+        internal static MetadataInfo Create(SubtitleStreamMetadata loader)
+        {
+            return new MetadataInfo
+            {
+                SubtitleMetadata = loader,
             };
         }
 

--- a/Hudl.FFmpeg/Resources/Ass.cs
+++ b/Hudl.FFmpeg/Resources/Ass.cs
@@ -1,0 +1,22 @@
+﻿using Hudl.FFmpeg.Attributes;
+using Hudl.FFmpeg.Resources.BaseTypes;
+using Hudl.FFmpeg.Resources.Interfaces;
+
+namespace Hudl.FFmpeg.Resources
+{
+    [ContainsStream(Type = typeof(SubtitleStream))]
+    public class Ass : BaseContainer
+    {
+        private const string FileFormat = ".ass";
+
+        public Ass()
+            : base(FileFormat)
+        {
+        }
+
+        protected override IContainer Clone()
+        {
+            return new Ass();
+        }
+    }
+}

--- a/Hudl.FFmpeg/Resources/BaseTypes/SubtitleStream.cs
+++ b/Hudl.FFmpeg/Resources/BaseTypes/SubtitleStream.cs
@@ -1,0 +1,41 @@
+﻿using Hudl.FFmpeg.Common;
+using Hudl.FFmpeg.Enums;
+using Hudl.FFmpeg.Metadata.Models;
+using Hudl.FFmpeg.Resources.Interfaces;
+
+namespace Hudl.FFmpeg.Resources.BaseTypes
+{
+    public class SubtitleStream : IStream
+    {
+        public SubtitleStream()
+        {
+            Map = Helpers.NewMap();
+            Info = MetadataInfo.Create();
+        }
+
+        private SubtitleStream(MetadataInfo info)
+            : this()
+        {
+            Info = info;
+        }
+
+        public string ResourceIndicator { get { return "s"; } }
+
+        public string Map { get; set; }
+
+        public MetadataInfo Info { get; set; }
+
+        public IStream Copy()
+        {
+            return new SubtitleStream
+            {
+                    Info = Info
+                };
+        }
+
+        public static SubtitleStream Create(MetadataInfo info)
+        {
+            return new SubtitleStream(info);
+        }
+    }
+}

--- a/Hudl.FFmpeg/Resources/Mkv.cs
+++ b/Hudl.FFmpeg/Resources/Mkv.cs
@@ -6,6 +6,7 @@ namespace Hudl.FFmpeg.Resources
 {
     [ContainsStream(Type = typeof(AudioStream))]
     [ContainsStream(Type = typeof(VideoStream))]
+    [ContainsStream(Type = typeof(SubtitleStream))]
     [ContainsStream(Type = typeof(DataStream))]
     public class Mkv : BaseContainer
     {

--- a/Hudl.FFmpeg/Resources/Srt.cs
+++ b/Hudl.FFmpeg/Resources/Srt.cs
@@ -1,0 +1,22 @@
+﻿using Hudl.FFmpeg.Attributes;
+using Hudl.FFmpeg.Resources.BaseTypes;
+using Hudl.FFmpeg.Resources.Interfaces;
+
+namespace Hudl.FFmpeg.Resources
+{
+    [ContainsStream(Type = typeof(SubtitleStream))]
+    public class Srt : BaseContainer
+    {
+        private const string FileFormat = ".srt";
+
+        public Srt()
+            : base(FileFormat)
+        {
+        }
+
+        protected override IContainer Clone()
+        {
+            return new Srt();
+        }
+    }
+}

--- a/Hudl.FFmpeg/Sugar/ResourceExtensions.cs
+++ b/Hudl.FFmpeg/Sugar/ResourceExtensions.cs
@@ -38,6 +38,13 @@ namespace Hudl.FFmpeg.Sugar
                     .Select(videoMetadata => VideoStream.Create(MetadataInfo.Create(videoMetadata))));
             }
 
+            if (mediaLoader.HasSubtitles)
+            {
+                resource.Streams.AddRange(mediaLoader.BaseData.Streams
+                    .OfType<SubtitleStreamMetadata>()
+                    .Select(subtitleMetadata => SubtitleStream.Create(MetadataInfo.Create(subtitleMetadata))));
+            }
+
             if (mediaLoader.HasData)
             {
                 resource.Streams.AddRange(mediaLoader.BaseData.Streams

--- a/Hudl.FFprobe/CodecTypes.cs
+++ b/Hudl.FFprobe/CodecTypes.cs
@@ -4,6 +4,7 @@
     {
         Video, 
         Audio,
+        Subtitle,
         Data,
     }
 }

--- a/Hudl.FFprobe/Hudl.FFprobe.csproj
+++ b/Hudl.FFprobe/Hudl.FFprobe.csproj
@@ -50,6 +50,8 @@
     <Compile Include="Metadata\Models\AudioFrameMetadata.cs" />
     <Compile Include="Metadata\Models\BaseFrameMetadata.cs" />
     <Compile Include="Metadata\Models\DataStreamMetadata.cs" />
+    <Compile Include="Metadata\Models\SubtitleFrameMetadata.cs" />
+    <Compile Include="Metadata\Models\SubtitleStreamMetadata.cs" />
     <Compile Include="Metadata\Models\VideoFrameMetadata.cs" />
     <Compile Include="Serialization\Converters\FractionConverter.cs" />
     <Compile Include="Serialization\Converters\RatioConverter.cs" />

--- a/Hudl.FFprobe/MediaLoader.cs
+++ b/Hudl.FFprobe/MediaLoader.cs
@@ -46,6 +46,7 @@ namespace Hudl.FFprobe
 
             HasAudio = containerMetadata.Streams != null && containerMetadata.Streams.OfType<AudioStreamMetadata>().Any();
             HasVideo = containerMetadata.Streams != null && containerMetadata.Streams.OfType<VideoStreamMetadata>().Any();
+            HasSubtitles = containerMetadata.Streams != null && containerMetadata.Streams.OfType<SubtitleStreamMetadata>().Any();
             HasData = containerMetadata.Streams != null && containerMetadata.Streams.OfType<DataStreamMetadata>().Any();
             HasFrames = containerMetadata.Frames != null && containerMetadata.Frames.Any();
             BaseData = containerMetadata;
@@ -61,6 +62,7 @@ namespace Hudl.FFprobe
 
         public bool HasVideo { get; protected set; }
         public bool HasAudio { get; protected set; }
+        public bool HasSubtitles { get; protected set; }
         public bool HasData { get; protected set; }
         public bool HasFrames { get; protected set; }
         public ContainerMetadata BaseData { get; protected set; }

--- a/Hudl.FFprobe/Metadata/Models/SubtitleFrameMetadata.cs
+++ b/Hudl.FFprobe/Metadata/Models/SubtitleFrameMetadata.cs
@@ -5,5 +5,9 @@ namespace Hudl.FFprobe.Metadata.Models
     [JsonObject]
     public class SubtitleFrameMetadata : BaseFrameMetadata
     {
+        public SubtitleFrameMetadata Copy()
+        {
+            return (SubtitleFrameMetadata)MemberwiseClone();
+        }
     }
 }

--- a/Hudl.FFprobe/Metadata/Models/SubtitleFrameMetadata.cs
+++ b/Hudl.FFprobe/Metadata/Models/SubtitleFrameMetadata.cs
@@ -1,0 +1,9 @@
+﻿using Newtonsoft.Json;
+
+namespace Hudl.FFprobe.Metadata.Models
+{
+    [JsonObject]
+    public class SubtitleFrameMetadata : BaseFrameMetadata
+    {
+    }
+}

--- a/Hudl.FFprobe/Metadata/Models/SubtitleStreamMetadata.cs
+++ b/Hudl.FFprobe/Metadata/Models/SubtitleStreamMetadata.cs
@@ -8,5 +8,9 @@ namespace Hudl.FFprobe.Metadata.Models
     [JsonObject]
     public class SubtitleStreamMetadata : BaseStreamMetadata
     {
+        public SubtitleStreamMetadata Copy()
+        {
+            return (SubtitleStreamMetadata)MemberwiseClone();
+        }
     }
 }

--- a/Hudl.FFprobe/Metadata/Models/SubtitleStreamMetadata.cs
+++ b/Hudl.FFprobe/Metadata/Models/SubtitleStreamMetadata.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace Hudl.FFprobe.Metadata.Models
+{
+    [JsonObject]
+    public class SubtitleStreamMetadata : BaseStreamMetadata
+    {
+    }
+}

--- a/Hudl.FFprobe/Serialization/Converters/FrameConverter.cs
+++ b/Hudl.FFprobe/Serialization/Converters/FrameConverter.cs
@@ -28,6 +28,11 @@ namespace Hudl.FFprobe.Serialization.Converters
                 return new AudioFrameMetadata();
             }
 
+            if (string.Equals(codecType, CodecTypes.Subtitle.ToString(), StringComparison.InvariantCultureIgnoreCase))
+            {
+                return new SubtitleFrameMetadata();
+            }
+
             return null; 
         }
 

--- a/Hudl.FFprobe/Serialization/Converters/StreamConverter.cs
+++ b/Hudl.FFprobe/Serialization/Converters/StreamConverter.cs
@@ -28,6 +28,11 @@ namespace Hudl.FFprobe.Serialization.Converters
                 return new AudioStreamMetadata();
             }
 
+            if (string.Equals(codecType, CodecTypes.Subtitle.ToString(), StringComparison.InvariantCultureIgnoreCase))
+            {
+                return new SubtitleStreamMetadata();
+            }
+
             if (string.Equals(codecType, CodecTypes.Data.ToString(), StringComparison.InvariantCultureIgnoreCase))
             {
                 return new DataStreamMetadata();


### PR DESCRIPTION
Hudl.FFprobe was just showing info about video and audio but nothing about incrusted or externals subtitles (ex in multilang mkv file).

TODO: Put some subtites properties in SubtitleStreamMetadata and SubtitleFrameMetadata. But the most important is already in tags (language).

TODO: Implement subtitle and ass filters for hard burn subtitles in video.

TODO: Set [ContainsStream(Type = typeof(SubtitleStream))] to Mp4 container because it supports embedded subtitles (but just like mov_text).

TODO: Implement how to copy as stream a srt subtitle file in mp4 and mkv containers.

    - Mp4: ffmpeg -i input.mp4 -f srt -i input.srt -map 0:0 -map 0:1 -map 1:0 -c:v copy -c:a copy -c:s mov_text output.mp4

    - Mkv: ffmpeg -i input.mp4 -f srt -i input.srt -map 0:0 -map 0:1 -map 1:0 -c:v copy -c:a copy -c:s srt  output.mkv

Note: In the last two TODO things maybe I fail ;)